### PR TITLE
refactor(compat): 抽取消息展示视图模型

### DIFF
--- a/client/components/chat/chat-message-row.tsx
+++ b/client/components/chat/chat-message-row.tsx
@@ -19,6 +19,7 @@ interface ChatMessageRowProps {
   onOpenUiAction: (event: ActionEvent) => void;
   onStructuredAction: (label: string) => void;
   onStructuredCommandAction: (command: string) => void;
+  onWidgetSlashCommand: (command: string) => Promise<void> | void;
   onRegenerate?: () => void;
 }
 
@@ -35,6 +36,7 @@ function ChatMessageRowComponent({
   onOpenUiAction,
   onStructuredAction,
   onStructuredCommandAction,
+  onWidgetSlashCommand,
   onRegenerate,
 }: ChatMessageRowProps) {
   const structuredContent = isSwipeStreaming ? streamingStructured : message.structuredContent;
@@ -56,6 +58,7 @@ function ChatMessageRowComponent({
       structuredContent={structuredContent}
       onStructuredAction={(label) => onStructuredAction(label)}
       onStructuredCommandAction={onStructuredCommandAction}
+      onWidgetSlashCommand={onWidgetSlashCommand}
       onRegenerate={onRegenerate}
     />
   );

--- a/client/components/chat/chat-panel.tsx
+++ b/client/components/chat/chat-panel.tsx
@@ -217,6 +217,7 @@ export function ChatPanel() {
                 onOpenUiAction={handleOpenUiAction}
                 onStructuredAction={handleStructuredAction}
                 onStructuredCommandAction={runSlashCommand}
+                onWidgetSlashCommand={runSlashCommand}
                 onRegenerate={isLastAssistant && !isGenerating ? handleGenerateSwipe : undefined}
               />
             );
@@ -236,6 +237,7 @@ export function ChatPanel() {
                 structuredContent={streamingStructured}
                 onStructuredAction={handleStructuredAction}
                 onStructuredCommandAction={runSlashCommand}
+                onWidgetSlashCommand={runSlashCommand}
               />
             )}
 

--- a/client/components/chat/compat-html-widget.tsx
+++ b/client/components/chat/compat-html-widget.tsx
@@ -1,0 +1,437 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { chatApi } from "@/lib/api/chat";
+import { ST_COMPAT_VARS_KEY } from "@/lib/compat/js-runtime";
+import type { CompatBridgeData } from "@/lib/compat/widget-pipeline";
+import { useChatStore } from "@/stores/chat-store";
+import { useCharacterStore } from "@/stores/character-store";
+import { useVariableStore } from "@/stores/variable-store";
+
+interface CompatHtmlWidgetProps {
+  messageId?: number;
+  swipeId: number;
+  html: string;
+  compatData: CompatBridgeData;
+  onRunSlashCommand?: (command: string) => Promise<void> | void;
+}
+
+type WidgetHostRpcRequest = {
+  __arcWidget: true;
+  widgetId: string;
+  type: "rpc";
+  id: string;
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+type WidgetHostEventRequest = {
+  __arcWidget: true;
+  widgetId: string;
+  type: "emit";
+  event: string;
+  detail?: unknown;
+};
+
+type WidgetHostReadyRequest = {
+  __arcWidget: true;
+  widgetId: string;
+  type: "ready";
+};
+
+type WidgetHostResizeRequest = {
+  __arcWidget: true;
+  widgetId: string;
+  type: "resize";
+  height?: number;
+};
+
+type WidgetIncomingMessage =
+  | WidgetHostRpcRequest
+  | WidgetHostEventRequest
+  | WidgetHostReadyRequest
+  | WidgetHostResizeRequest;
+
+function getCompatVarRow(messageId: number | undefined, swipeId: number): Record<string, unknown> {
+  if (!messageId) return {};
+
+  const message = useChatStore.getState().messages.find((item) => item.id === messageId);
+  const raw = message?.extra?.[ST_COMPAT_VARS_KEY];
+  if (!Array.isArray(raw)) return {};
+
+  const row = raw[swipeId];
+  return row && typeof row === "object" ? { ...(row as Record<string, unknown>) } : {};
+}
+
+function buildBridgeBootstrap(widgetId: string): string {
+  return `
+<script>
+(function () {
+  var __widgetId = ${JSON.stringify(widgetId)};
+  var __listeners = new Map();
+  var __pending = new Map();
+  var __counter = 0;
+
+  function __notifyResize() {
+    var height = 240;
+    try {
+      var body = document.body;
+      var docEl = document.documentElement;
+      height = Math.max(
+        body ? body.scrollHeight : 0,
+        body ? body.offsetHeight : 0,
+        docEl ? docEl.scrollHeight : 0,
+        docEl ? docEl.offsetHeight : 0,
+        240
+      );
+    } catch (error) {}
+
+    parent.postMessage(
+      { __arcWidget: true, widgetId: __widgetId, type: "resize", height: height },
+      "*"
+    );
+  }
+
+  function __dispatch(eventName, detail) {
+    var handlers = __listeners.get(eventName);
+    if (!handlers) return;
+    handlers.forEach(function (handler) {
+      try {
+        handler(detail);
+      } catch (error) {
+        console.error("[compat-widget] listener error", error);
+      }
+    });
+  }
+
+  function __rpc(method, params) {
+    return new Promise(function (resolve, reject) {
+      var id = "__arc_widget_rpc_" + (++__counter);
+      __pending.set(id, { resolve: resolve, reject: reject });
+      parent.postMessage(
+        { __arcWidget: true, widgetId: __widgetId, type: "rpc", id: id, method: method, params: params || {} },
+        "*"
+      );
+    });
+  }
+
+  async function __loadIntoTarget(target, url) {
+    var response = await fetch(url);
+    var html = await response.text();
+    var parser = new DOMParser();
+    var parsed = parser.parseFromString(html, "text/html");
+
+    Array.from(parsed.head.querySelectorAll("style, link[rel='stylesheet']")).forEach(function (node) {
+      document.head.appendChild(node.cloneNode(true));
+    });
+
+    if (target) {
+      target.innerHTML = parsed.body ? parsed.body.innerHTML : html;
+    }
+
+    var scriptNodes = Array.from(parsed.querySelectorAll("script"));
+    for (var i = 0; i < scriptNodes.length; i += 1) {
+      var source = scriptNodes[i];
+      var script = document.createElement("script");
+      Array.from(source.attributes).forEach(function (attr) {
+        script.setAttribute(attr.name, attr.value);
+      });
+      script.textContent = source.textContent;
+      document.body.appendChild(script);
+    }
+
+    __notifyResize();
+  }
+
+  window.eventOn = function (eventName, handler) {
+    if (!__listeners.has(eventName)) {
+      __listeners.set(eventName, new Set());
+    }
+    __listeners.get(eventName).add(handler);
+    return function () {
+      var handlers = __listeners.get(eventName);
+      if (handlers) handlers.delete(handler);
+    };
+  };
+
+  window.eventEmit = function (eventName, detail) {
+    parent.postMessage(
+      { __arcWidget: true, widgetId: __widgetId, type: "emit", event: eventName, detail: detail },
+      "*"
+    );
+  };
+
+  window.ArcTavern = {
+    getContext: function () { return __rpc("getContext"); },
+    getVariable: function (name, scope) { return __rpc("getVariable", { name: name, scope: scope || "auto" }); },
+    setVariable: function (name, value, scope) { return __rpc("setVariable", { name: name, value: value, scope: scope || "compat" }); },
+    runSlashCommand: function (command) { return __rpc("runSlashCommand", { command: command }); },
+    requestWriteDone: function () { return __rpc("requestWriteDone"); },
+    requestUiRefresh: function () { __notifyResize(); }
+  };
+
+  window.$ = function (selector) {
+    var target = typeof selector === "string" ? document.querySelector(selector) : selector;
+    return {
+      load: function (url) {
+        return __loadIntoTarget(target, url);
+      }
+    };
+  };
+
+  window.addEventListener("message", function (event) {
+    if (event.source !== parent) return;
+    var data = event.data;
+    if (!data || data.__arcWidget !== true || data.widgetId !== __widgetId) return;
+
+    if (data.type === "dispatch") {
+      __dispatch(data.event, data.detail);
+      return;
+    }
+
+    if (data.type === "rpcResult") {
+      var pending = __pending.get(data.id);
+      if (!pending) return;
+      __pending.delete(data.id);
+      if (data.error) {
+        pending.reject(new Error(data.error));
+      } else {
+        pending.resolve(data.result);
+      }
+    }
+  });
+
+  window.addEventListener("load", __notifyResize);
+  document.addEventListener("DOMContentLoaded", __notifyResize);
+  if (typeof ResizeObserver !== "undefined") {
+    new ResizeObserver(__notifyResize).observe(document.documentElement);
+  }
+
+  parent.postMessage({ __arcWidget: true, widgetId: __widgetId, type: "ready" }, "*");
+})();
+</script>`;
+}
+
+function injectBootstrap(html: string, widgetId: string): string {
+  const bootstrap = buildBridgeBootstrap(widgetId);
+
+  if (/<\/head>/i.test(html)) {
+    return html.replace(/<\/head>/i, `${bootstrap}</head>`);
+  }
+
+  if (/<body[^>]*>/i.test(html)) {
+    return html.replace(/<body([^>]*)>/i, `<body$1>${bootstrap}`);
+  }
+
+  return `<!DOCTYPE html><html><head>${bootstrap}</head><body>${html}</body></html>`;
+}
+
+export function CompatHtmlWidget({
+  messageId,
+  swipeId,
+  html,
+  compatData,
+  onRunSlashCommand,
+}: CompatHtmlWidgetProps) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const widgetIdRef = useRef(`arc-widget-${crypto.randomUUID()}`);
+  const [height, setHeight] = useState(280);
+
+  const srcDoc = useMemo(() => injectBootstrap(html, widgetIdRef.current), [html]);
+
+  useEffect(() => {
+    async function updateCompatVariable(name: string, value: unknown) {
+      if (!messageId) return;
+
+      const message = useChatStore.getState().messages.find((item) => item.id === messageId);
+      if (!message) return;
+
+      const extra = { ...message.extra };
+      const raw = extra[ST_COMPAT_VARS_KEY];
+      const rows = Array.isArray(raw) ? [...raw] : [];
+      while (rows.length <= swipeId) {
+        rows.push({});
+      }
+
+      const row =
+        rows[swipeId] && typeof rows[swipeId] === "object"
+          ? { ...(rows[swipeId] as Record<string, unknown>) }
+          : {};
+
+      row[name] = value;
+      rows[swipeId] = row;
+      extra[ST_COMPAT_VARS_KEY] = rows;
+
+      const updated = await chatApi.updateMessage(messageId, { extra });
+      useChatStore.setState((state) => ({
+        messages: state.messages.map((item) => (item.id === messageId ? updated : item)),
+      }));
+    }
+
+    function postToWidget(message: Record<string, unknown>) {
+      iframeRef.current?.contentWindow?.postMessage(
+        {
+          __arcWidget: true,
+          widgetId: widgetIdRef.current,
+          ...message,
+        },
+        "*",
+      );
+    }
+
+    function buildContext() {
+      const variableStore = useVariableStore.getState();
+      const characterStore = useCharacterStore.getState();
+      const characterId = characterStore.selectedId;
+      const character = characterStore.characters.find((item) => item.id === characterId);
+      const messages = useChatStore
+        .getState()
+        .messages.map((item) => ({ id: item.id, role: item.role, content: item.content }));
+
+      return {
+        compatData,
+        globalVariables: variableStore.globalVariables,
+        chatVariables: variableStore.chatVariables,
+        compatVariables: getCompatVarRow(messageId, swipeId),
+        character: {
+          id: character?.id ?? null,
+          name: character?.name ?? "",
+          avatar: character?.avatar ?? "",
+        },
+        message: {
+          id: messageId ?? null,
+          swipeId,
+          extra:
+            useChatStore.getState().messages.find((item) => item.id === messageId)?.extra ?? {},
+        },
+        messages,
+      };
+    }
+
+    async function handleRpc(method: string, params: Record<string, unknown> = {}) {
+      const variableStore = useVariableStore.getState();
+      const compatRow = getCompatVarRow(messageId, swipeId);
+      const name = typeof params.name === "string" ? params.name : "";
+      const scope = typeof params.scope === "string" ? params.scope : "auto";
+
+      switch (method) {
+        case "getContext":
+          return buildContext();
+        case "requestWriteDone":
+          return { statWithoutMeta: compatData.statWithoutMeta };
+        case "getVariable":
+          if (!name) return undefined;
+          if (scope === "compat") return compatRow[name];
+          if (scope === "chat") return variableStore.chatVariables[name];
+          if (scope === "global") return variableStore.globalVariables[name];
+          return (
+            compatRow[name] ??
+            variableStore.chatVariables[name] ??
+            variableStore.globalVariables[name]
+          );
+        case "setVariable": {
+          if (!name) return false;
+          const value = params.value;
+          if (scope === "global") {
+            variableStore.setGlobalVariable(name, String(value ?? ""));
+            return true;
+          }
+          if (scope === "chat") {
+            variableStore.setChatVariable(name, String(value ?? ""));
+            return true;
+          }
+          await updateCompatVariable(name, value);
+          return true;
+        }
+        case "runSlashCommand": {
+          const command = typeof params.command === "string" ? params.command : "";
+          if (!command || !onRunSlashCommand) return false;
+          await onRunSlashCommand(command);
+          return true;
+        }
+        default:
+          return undefined;
+      }
+    }
+
+    async function handleMessage(event: MessageEvent) {
+      if (event.source !== iframeRef.current?.contentWindow) return;
+
+      const data = event.data as WidgetIncomingMessage | null;
+      if (!data || data.__arcWidget !== true || data.widgetId !== widgetIdRef.current) return;
+
+      if (data.type === "resize") {
+        setHeight(Math.max(Number(data.height ?? 0), 240));
+        return;
+      }
+
+      if (data.type === "ready") {
+        postToWidget({
+          type: "dispatch",
+          event: "arctavern:context",
+          detail: buildContext(),
+        });
+        return;
+      }
+
+      if (data.type === "emit") {
+        if (data.event === "era:requestWriteDone") {
+          postToWidget({
+            type: "dispatch",
+            event: "era:writeDone",
+            detail: { statWithoutMeta: compatData.statWithoutMeta },
+          });
+        } else if (data.event === "arctavern:requestContext") {
+          postToWidget({
+            type: "dispatch",
+            event: "arctavern:context",
+            detail: buildContext(),
+          });
+        } else if (
+          data.event === "slash:run" &&
+          data.detail &&
+          typeof data.detail === "object" &&
+          "command" in data.detail &&
+          typeof data.detail.command === "string" &&
+          onRunSlashCommand
+        ) {
+          await onRunSlashCommand(data.detail.command);
+        }
+        return;
+      }
+
+      if (data.type === "rpc") {
+        try {
+          const result = await handleRpc(data.method, data.params);
+          postToWidget({
+            type: "rpcResult",
+            id: data.id,
+            result,
+          });
+        } catch (error) {
+          postToWidget({
+            type: "rpcResult",
+            id: data.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [compatData, messageId, onRunSlashCommand, swipeId]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      title="Compat HTML Widget"
+      sandbox="allow-forms allow-modals allow-popups allow-scripts"
+      className="w-full rounded-md border border-border/60 bg-background"
+      style={{ height }}
+      srcDoc={srcDoc}
+    />
+  );
+}

--- a/client/components/chat/compat-widget-message.tsx
+++ b/client/components/chat/compat-widget-message.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { CompatMarkdown } from "@/lib/compat/markdown-pipeline";
+import type { AssistantRenderSegment, CompatBridgeData } from "@/lib/compat/widget-pipeline";
+import { CompatHtmlWidget } from "./compat-html-widget";
+
+interface CompatWidgetMessageProps {
+  messageId?: number;
+  swipeId: number;
+  segments: AssistantRenderSegment[];
+  compatData: CompatBridgeData;
+  markdownClassName?: string;
+  onWidgetSlashCommand?: (command: string) => Promise<void> | void;
+}
+
+export function CompatWidgetMessage({
+  messageId,
+  swipeId,
+  segments,
+  compatData,
+  markdownClassName,
+  onWidgetSlashCommand,
+}: CompatWidgetMessageProps) {
+  return (
+    <div className="space-y-4">
+      {segments.map((segment, index) => {
+        if (segment.type === "widget") {
+          return (
+            <CompatHtmlWidget
+              key={`widget-${index}`}
+              messageId={messageId}
+              swipeId={swipeId}
+              html={segment.html}
+              compatData={compatData}
+              onRunSlashCommand={onWidgetSlashCommand}
+            />
+          );
+        }
+
+        return (
+          <CompatMarkdown
+            key={`markdown-${index}`}
+            content={segment.content}
+            className={markdownClassName}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/client/components/chat/message-bubble.tsx
+++ b/client/components/chat/message-bubble.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "@/lib/i18n";
 import { StreamingText } from "./streaming-text";
 import { OpenUiMessage } from "./openui-message";
 import { StructuredMessage } from "./structured-message";
+import { CompatWidgetMessage } from "./compat-widget-message";
 import { isOpenUiLang } from "@/lib/openui";
 import { type PartialStructuredResponse } from "@/lib/openui/structured-types";
 import type { ActionEvent } from "@openuidev/react-lang";
@@ -13,6 +14,7 @@ import { DotsLoader } from "@/components/ui/loader";
 import { useContentPreprocessor } from "@/hooks/use-content-preprocessor";
 import { useMessageScriptRuntime } from "@/hooks/use-message-script-runtime";
 import { CompatMarkdown } from "@/lib/compat/markdown-pipeline";
+import { prepareMessageViewModel } from "@/lib/compat/message-view-model";
 import {
   ChainOfThought,
   ChainOfThoughtHeader,
@@ -49,6 +51,7 @@ interface MessageBubbleProps {
   structuredContent?: PartialStructuredResponse | null;
   onStructuredAction?: (label: string, value: string) => void;
   onStructuredCommandAction?: (command: string) => void;
+  onWidgetSlashCommand?: (command: string) => Promise<void> | void;
 }
 
 function ActionButton({
@@ -102,21 +105,20 @@ export function MessageBubble({
   structuredContent,
   onStructuredAction,
   onStructuredCommandAction,
+  onWidgetSlashCommand,
 }: MessageBubbleProps) {
   const { t } = useTranslation();
   const { formatAssistantForDisplay, preprocess } = useContentPreprocessor();
   const isUser = role === "user";
 
-  const { display, scripts, thinking } =
-    role === "assistant"
-      ? formatAssistantForDisplay(content)
-      : { display: preprocess(content, role), scripts: [], thinking: "" };
-
-  const combinedReasoning = [reasoning, thinking].filter(Boolean).join("\n\n") || undefined;
-  const reasoningDisplay =
-    combinedReasoning && role === "assistant"
-      ? formatAssistantForDisplay(combinedReasoning).display
-      : combinedReasoning;
+  const { display, scripts, segments, compatData, reasoningDisplay, hasWidgets } =
+    prepareMessageViewModel({
+      role,
+      content,
+      reasoning,
+      formatAssistantForDisplay,
+      preprocess,
+    });
 
   const hasStructured = Boolean(structuredContent && structuredContent.blocks?.length);
 
@@ -170,6 +172,15 @@ export function MessageBubble({
           />
         ) : isStreaming && !content && !structuredContent ? (
           <DotsLoader size="md" className="text-muted-foreground" />
+        ) : !isStreaming && hasWidgets ? (
+          <CompatWidgetMessage
+            messageId={messageId}
+            swipeId={swipeId}
+            segments={segments}
+            compatData={compatData}
+            markdownClassName={markdownStyles}
+            onWidgetSlashCommand={onWidgetSlashCommand}
+          />
         ) : openUiEnabled && isOpenUiLang(display) ? (
           <OpenUiMessage content={display} isStreaming={isStreaming} onAction={onOpenUiAction} />
         ) : isStreaming ? (

--- a/client/hooks/use-content-preprocessor.ts
+++ b/client/hooks/use-content-preprocessor.ts
@@ -1,7 +1,8 @@
 /** Compat 层入口：regex/XML 预处理 + 助手展示管线（与 `lib/compat/` 配套）。 */
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useCharacterStore } from "@/stores/character-store";
+import { useRegexStore } from "@/stores/regex-store";
 import { preprocessContent } from "@/lib/compat/preprocessor";
 import {
   prepareAssistantDisplay,
@@ -11,6 +12,10 @@ import {
 export function useContentPreprocessor() {
   const characters = useCharacterStore((s) => s.characters);
   const selectedId = useCharacterStore((s) => s.selectedId);
+  const globalScripts = useRegexStore((s) => s.globalScripts);
+  const loadingGlobalScripts = useRegexStore((s) => s.loading);
+  const loadedGlobalScripts = useRegexStore((s) => s.loadedGlobalScripts);
+  const fetchGlobalScripts = useRegexStore((s) => s.fetchGlobalScripts);
 
   const extensions = useMemo(() => {
     if (!selectedId) return null;
@@ -18,17 +23,31 @@ export function useContentPreprocessor() {
     return char?.extensions ?? null;
   }, [characters, selectedId]);
 
+  useEffect(() => {
+    if (!loadedGlobalScripts && !loadingGlobalScripts) {
+      void fetchGlobalScripts();
+    }
+  }, [fetchGlobalScripts, loadedGlobalScripts, loadingGlobalScripts]);
+
   return useMemo(() => {
     return {
       preprocess: (content: string, role: string): string => {
         if (role !== "assistant" || !content) return content;
-        return preprocessContent(content, extensions);
+        return preprocessContent(content, extensions, globalScripts);
       },
       formatAssistantForDisplay: (content: string): PreparedAssistantDisplay => {
-        if (!content) return { display: "", scripts: [], thinking: "" };
-        const preprocessed = preprocessContent(content, extensions);
-        return prepareAssistantDisplay(preprocessed);
+        if (!content) {
+          return {
+            display: "",
+            scripts: [],
+            thinking: "",
+            segments: [],
+            compatData: {},
+          };
+        }
+        const preprocessed = preprocessContent(content, extensions, globalScripts);
+        return prepareAssistantDisplay(content, preprocessed);
       },
     };
-  }, [extensions]);
+  }, [extensions, globalScripts]);
 }

--- a/client/lib/compat/__tests__/preprocessor.test.ts
+++ b/client/lib/compat/__tests__/preprocessor.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { preprocessContent } from "../preprocessor";
+import type { RegexScriptData } from "../regex-engine";
+
+describe("preprocessContent", () => {
+  it("applies global ai_output regex scripts before XML stripping", () => {
+    const globalScripts: RegexScriptData[] = [
+      {
+        scriptName: "opening-html",
+        findRegex: "/<opening>([\\s\\S]*?)<\\/opening>/gi",
+        replaceString: "<strong>$1</strong>",
+        placement: [2],
+      },
+    ];
+
+    expect(preprocessContent("<opening>Hello</opening>", null, globalScripts)).toBe(
+      "<strong>Hello</strong>",
+    );
+  });
+
+  it("preserves regex-generated HTML through XML stripping", () => {
+    const extensions = {
+      regex_scripts: [
+        {
+          scriptName: "legacy-font",
+          findRegex: "/<gametxt>([\\s\\S]*?)<\\/gametxt>/gi",
+          replaceString: '<font color="red">$1</font>',
+          placement: [2],
+        },
+      ],
+    };
+
+    expect(preprocessContent("<gametxt>Hello</gametxt>", extensions)).toBe(
+      '<font color="red">Hello</font>',
+    );
+  });
+
+  it("preserves widget documents before XML stripping", () => {
+    const extensions = {
+      regex_scripts: [
+        {
+          scriptName: "widget-doc",
+          findRegex: "/<StatusPlaceHolderImpl\\/>/gi",
+          replaceString:
+            '```html\n<!DOCTYPE html><html><head><style>.app{color:red;}</style></head><body><div class="app">Hello</div><script>window.foo = 1;</script></body></html>\n```',
+          placement: [2],
+        },
+      ],
+    };
+
+    expect(preprocessContent("<StatusPlaceHolderImpl/>", extensions)).toContain(
+      "<style>.app{color:red;}</style>",
+    );
+    expect(preprocessContent("<StatusPlaceHolderImpl/>", extensions)).toContain(
+      "<script>window.foo = 1;</script>",
+    );
+  });
+});

--- a/client/lib/compat/__tests__/widget-pipeline.test.ts
+++ b/client/lib/compat/__tests__/widget-pipeline.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { extractAssistantRenderSegments, extractCompatBridgeData } from "../widget-pipeline";
+
+describe("extractCompatBridgeData", () => {
+  it("extracts variableinsert JSON as statWithoutMeta", () => {
+    const raw = `<VariableInsert>
+{"player":{"name":"Alice"},"world_state":{"location":"旧校舍"}}
+</VariableInsert>`;
+
+    expect(extractCompatBridgeData(raw)).toEqual({
+      statWithoutMeta: {
+        player: { name: "Alice" },
+        world_state: { location: "旧校舍" },
+      },
+      variableInsert: {
+        player: { name: "Alice" },
+        world_state: { location: "旧校舍" },
+      },
+    });
+  });
+});
+
+describe("extractAssistantRenderSegments", () => {
+  it("extracts fenced HTML documents as widget segments", () => {
+    const content = `前文\n\`\`\`html\n<!DOCTYPE html><html><body><div id="app"></div></body></html>\n\`\`\`\n后文`;
+    const segments = extractAssistantRenderSegments(content);
+
+    expect(segments).toEqual([
+      { type: "markdown", content: "前文\n" },
+      {
+        type: "widget",
+        html: '<!DOCTYPE html><html><body><div id="app"></div></body></html>',
+      },
+      { type: "markdown", content: "\n后文" },
+    ]);
+  });
+
+  it("extracts raw HTML documents as widget segments", () => {
+    const content = `说明\n<!DOCTYPE html><html><body><div id="app"></div></body></html>`;
+    const segments = extractAssistantRenderSegments(content);
+
+    expect(segments).toEqual([
+      { type: "markdown", content: "说明\n" },
+      {
+        type: "widget",
+        html: '<!DOCTYPE html><html><body><div id="app"></div></body></html>',
+      },
+    ]);
+  });
+});

--- a/client/lib/compat/__tests__/xml-tag-stripper.test.ts
+++ b/client/lib/compat/__tests__/xml-tag-stripper.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { stripXmlTags } from "../xml-tag-stripper";
 
 describe("stripXmlTags", () => {
@@ -24,6 +24,19 @@ describe("stripXmlTags", () => {
     );
   });
 
+  it("removes compat data blocks whose contents should never be displayed", () => {
+    const raw = [
+      "before",
+      "<VariableInsert>{\"player\":{\"name\":\"Alice\"}}</VariableInsert>",
+      "<VariableEdit>{\"player\":{\"hp\":5}}</VariableEdit>",
+      "<VariableDelete>{\"player\":{\"status\":true}}</VariableDelete>",
+      "<era_data>{\"era\":1}</era_data>",
+      "after",
+    ].join("\n");
+
+    expect(stripXmlTags(raw)).toBe("before\n\nafter");
+  });
+
   it("handles mixed tags", () => {
     const input = `<customized>
 你想要什么样的自定义开局？都满足你
@@ -42,7 +55,21 @@ describe("stripXmlTags", () => {
   });
 
   it("preserves standard HTML tags", () => {
-    expect(stripXmlTags("<b>bold</b> and <em>italic</em>")).toBe("<b>bold</b> and <em>italic</em>");
+    expect(stripXmlTags("<b>bold</b> and <em>italic</em>")).toBe(
+      "<b>bold</b> and <em>italic</em>",
+    );
+  });
+
+  it("preserves allowed style tags", () => {
+    expect(stripXmlTags('<style>.app{color:red;}</style><div>Hello</div>')).toBe(
+      '<style>.app{color:red;}</style><div>Hello</div>',
+    );
+  });
+
+  it("keeps supported HTML tags while stripping unknown compat wrappers", () => {
+    expect(stripXmlTags("<scroll><div><strong>Hello</strong></div></scroll>")).toBe(
+      "<div><strong>Hello</strong></div>",
+    );
   });
 
   it("strips orphaned opening tags", () => {

--- a/client/lib/compat/display-pipeline.ts
+++ b/client/lib/compat/display-pipeline.ts
@@ -6,18 +6,65 @@
 
 import { partitionScripts } from "@/lib/compat/js-runtime/extractor";
 import { extractThinking } from "@/lib/compat/thinking-extractor";
+import {
+  extractAssistantRenderSegments,
+  extractCompatBridgeData,
+  type AssistantRenderSegment,
+  type CompatBridgeData,
+} from "@/lib/compat/widget-pipeline";
 
 export interface PreparedAssistantDisplay {
   display: string;
   scripts: string[];
   thinking: string;
+  segments: AssistantRenderSegment[];
+  compatData: CompatBridgeData;
 }
 
-export function prepareAssistantDisplay(preprocessed: string): PreparedAssistantDisplay {
-  if (!preprocessed) return { display: "", scripts: [], thinking: "" };
+export function prepareAssistantDisplay(
+  rawContent: string,
+  preprocessed: string,
+): PreparedAssistantDisplay {
+  if (!preprocessed) {
+    return {
+      display: "",
+      scripts: [],
+      thinking: "",
+      segments: [],
+      compatData: extractCompatBridgeData(rawContent),
+    };
+  }
 
+  const compatData = extractCompatBridgeData(rawContent);
   const { thinking, cleaned } = extractThinking(preprocessed);
-  const { display, scripts } = partitionScripts(cleaned);
+  const rawSegments = extractAssistantRenderSegments(cleaned);
+  const scripts: string[] = [];
+  const segments = rawSegments.map((segment) => {
+    if (segment.type === "widget") {
+      return segment;
+    }
 
-  return { display, scripts, thinking };
+    const partitioned = partitionScripts(segment.content);
+    scripts.push(...partitioned.scripts);
+    return {
+      type: "markdown" as const,
+      content: partitioned.display,
+    };
+  });
+
+  const display = segments
+    .filter(
+      (segment): segment is Extract<AssistantRenderSegment, { type: "markdown" }> =>
+        segment.type === "markdown",
+    )
+    .map((segment) => segment.content)
+    .join("\n\n");
+
+  return {
+    display,
+    scripts,
+    thinking,
+    segments,
+    compatData,
+  };
 }

--- a/client/lib/compat/html-tags.ts
+++ b/client/lib/compat/html-tags.ts
@@ -1,0 +1,32 @@
+import { defaultSchema } from "rehype-sanitize";
+
+const extraTagNames = [
+  "article",
+  "aside",
+  "br",
+  "button",
+  "center",
+  "details",
+  "div",
+  "em",
+  "figcaption",
+  "figure",
+  "font",
+  "footer",
+  "header",
+  "hr",
+  "main",
+  "nav",
+  "p",
+  "section",
+  "span",
+  "strong",
+  "style",
+  "summary",
+  "time",
+] as const;
+
+const baseTagNames = defaultSchema.tagNames ?? [];
+
+export const stCompatAllowedTagNames = [...new Set([...baseTagNames, ...extraTagNames])];
+export const stCompatAllowedTagNameSet = new Set(stCompatAllowedTagNames);

--- a/client/lib/compat/message-view-model.ts
+++ b/client/lib/compat/message-view-model.ts
@@ -1,0 +1,52 @@
+import type { PreparedAssistantDisplay } from "@/lib/compat/display-pipeline";
+
+type MessageRole = "user" | "assistant" | "system" | "tool";
+
+export interface PreparedMessageViewModel extends PreparedAssistantDisplay {
+  reasoningDisplay?: string;
+  hasWidgets: boolean;
+}
+
+interface PrepareMessageViewModelParams {
+  role: MessageRole;
+  content: string;
+  reasoning?: string;
+  formatAssistantForDisplay: (content: string) => PreparedAssistantDisplay;
+  preprocess: (content: string, role: string) => string;
+}
+
+const emptyAssistantDisplay: PreparedAssistantDisplay = {
+  display: "",
+  scripts: [],
+  thinking: "",
+  segments: [],
+  compatData: {},
+};
+
+export function prepareMessageViewModel({
+  role,
+  content,
+  reasoning,
+  formatAssistantForDisplay,
+  preprocess,
+}: PrepareMessageViewModelParams): PreparedMessageViewModel {
+  const prepared =
+    role === "assistant"
+      ? formatAssistantForDisplay(content)
+      : {
+          ...emptyAssistantDisplay,
+          display: preprocess(content, role),
+        };
+
+  const combinedReasoning = [reasoning, prepared.thinking].filter(Boolean).join("\n\n") || undefined;
+  const reasoningDisplay =
+    combinedReasoning && role === "assistant"
+      ? formatAssistantForDisplay(combinedReasoning).display
+      : combinedReasoning;
+
+  return {
+    ...prepared,
+    reasoningDisplay,
+    hasWidgets: prepared.segments.some((segment) => segment.type === "widget"),
+  };
+}

--- a/client/lib/compat/preprocessor.ts
+++ b/client/lib/compat/preprocessor.ts
@@ -9,25 +9,60 @@
  * (strip `<script>` for ReactMarkdown + optional js-runtime).
  */
 
-import { getDisplayRegexScripts, applyRegexScripts } from "./regex-engine";
+import {
+  getDisplayRegexScripts,
+  getPlacementRegexScripts,
+  applyRegexScripts,
+} from "./regex-engine";
+import type { RegexScriptData } from "./regex-engine";
+import { extractAssistantRenderSegments } from "./widget-pipeline";
 import { stripXmlTags } from "./xml-tag-stripper";
 
 export function preprocessContent(
   content: string,
   extensions?: Record<string, unknown> | null,
+  globalScripts?: RegexScriptData[],
 ): string {
   if (!content) return content;
 
   let result = content;
 
-  // 1. Execute character-scoped regex scripts (AI_OUTPUT placement)
-  const scripts = getDisplayRegexScripts(extensions);
+  // 1. Execute global + character-scoped regex scripts (AI_OUTPUT placement).
+  // Character scripts run after global ones so per-character rules can override shared cleanup.
+  const scripts = [
+    ...getPlacementRegexScripts(globalScripts, "ai_output"),
+    ...getDisplayRegexScripts(extensions),
+  ];
   if (scripts.length > 0) {
     result = applyRegexScripts(result, scripts, "ai_output");
   }
 
-  // 2. Strip remaining custom XML tags
-  result = stripXmlTags(result);
+  // 2. Protect full widget documents before XML stripping so their internal
+  // html/head/style/script tags survive for the sandboxed widget renderer.
+  const widgetSegments = extractAssistantRenderSegments(result);
+  if (widgetSegments.some((segment) => segment.type === "widget")) {
+    const widgetTokens = new Map<string, string>();
+    const protectedContent = widgetSegments
+      .map((segment, index) => {
+        if (segment.type === "markdown") {
+          return segment.content;
+        }
+
+        const token = `__ARC_WIDGET_TOKEN_${index}__`;
+        widgetTokens.set(token, segment.html);
+        return token;
+      })
+      .join("");
+
+    result = stripXmlTags(protectedContent);
+
+    for (const [token, html] of widgetTokens.entries()) {
+      result = result.replace(token, html);
+    }
+  } else {
+    // 3. Strip remaining custom XML tags
+    result = stripXmlTags(result);
+  }
 
   return result;
 }

--- a/client/lib/compat/regex-engine.ts
+++ b/client/lib/compat/regex-engine.ts
@@ -25,6 +25,17 @@ export interface RegexScriptData {
   maxDepth?: number | null;
 }
 
+function isEnabledDisplayScript(s: unknown, placementValue: number): s is RegexScriptData {
+  if (!s || typeof s !== "object") return false;
+  const script = s as RegexScriptData;
+  return (
+    !script.disabled &&
+    typeof script.findRegex === "string" &&
+    Array.isArray(script.placement) &&
+    script.placement.includes(placementValue)
+  );
+}
+
 /**
  * Parse a regex string like `/pattern/flags` into a RegExp.
  * Falls back to `new RegExp(str)` if not in slash notation.
@@ -111,16 +122,20 @@ export function getDisplayRegexScripts(
   const scripts = extensions.regex_scripts;
   if (!Array.isArray(scripts)) return [];
 
-  return scripts.filter((s: unknown): s is RegexScriptData => {
-    if (!s || typeof s !== "object") return false;
-    const script = s as RegexScriptData;
-    return (
-      !script.disabled &&
-      typeof script.findRegex === "string" &&
-      Array.isArray(script.placement) &&
-      script.placement.includes(PLACEMENT_AI_OUTPUT)
-    );
-  });
+  return scripts.filter((s: unknown): s is RegexScriptData =>
+    isEnabledDisplayScript(s, PLACEMENT_AI_OUTPUT),
+  );
+}
+
+export function getPlacementRegexScripts(
+  scripts: unknown,
+  placement: "ai_output" | "user_input",
+): RegexScriptData[] {
+  if (!Array.isArray(scripts)) return [];
+  const placementValue = placement === "ai_output" ? PLACEMENT_AI_OUTPUT : PLACEMENT_USER_INPUT;
+  return scripts.filter((s: unknown): s is RegexScriptData =>
+    isEnabledDisplayScript(s, placementValue),
+  );
 }
 
 /**

--- a/client/lib/compat/sanitize-schema.ts
+++ b/client/lib/compat/sanitize-schema.ts
@@ -4,27 +4,15 @@
  */
 
 import { defaultSchema, type Options as SanitizeOptions } from "rehype-sanitize";
-
-const extraTagNames = [
-  "div",
-  "span",
-  "br",
-  "hr",
-  "em",
-  "strong",
-  "details",
-  "summary",
-  "p",
-] as const;
-
-const baseTags = defaultSchema.tagNames ?? [];
+import { stCompatAllowedTagNames } from "@/lib/compat/html-tags";
 
 export const stCompatSanitizeSchema: SanitizeOptions = {
   ...defaultSchema,
-  tagNames: [...new Set([...baseTags, ...extraTagNames])],
+  tagNames: stCompatAllowedTagNames,
   attributes: {
     ...defaultSchema.attributes,
     "*": [...new Set([...(defaultSchema.attributes?.["*"] ?? []), "style", "class"])],
     details: [...new Set([...(defaultSchema.attributes?.details ?? []), "open"])],
+    font: ["color", "face", "size"],
   },
 };

--- a/client/lib/compat/widget-pipeline.ts
+++ b/client/lib/compat/widget-pipeline.ts
@@ -1,0 +1,159 @@
+export interface CompatBridgeData {
+  statWithoutMeta?: unknown;
+  variableInsert?: unknown;
+  eraData?: unknown;
+}
+
+export type AssistantRenderSegment =
+  | { type: "markdown"; content: string }
+  | { type: "widget"; html: string };
+
+const COMPAT_DATA_BLOCK_RE =
+  /<(variableinsert|variableedit|variabledelete|era_data)>\s*([\s\S]*?)\s*<\/\1>/gi;
+
+const FENCED_BLOCK_RE = /```(?:html)?\s*([\s\S]*?)```/gi;
+const RAW_DOCUMENT_RE =
+  /(?:<!DOCTYPE\s+html[\s\S]*?<\/html>)|(?:<html[\s\S]*?<\/html>)|(?:<body[\s\S]*?<\/body>)/gi;
+
+function tryParseStructuredValue(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+
+  if (
+    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]"))
+  ) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }
+
+  return trimmed;
+}
+
+function looksLikeWidgetDocument(content: string): boolean {
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+
+  return (
+    /^(?:<!DOCTYPE\s+html\b|<html\b|<body\b)/i.test(trimmed) ||
+    (/<(?:style|script|head|meta|link)\b/i.test(trimmed) &&
+      /<(?:div|section|main|body)\b/i.test(trimmed))
+  );
+}
+
+function splitByPattern(
+  input: AssistantRenderSegment[],
+  pattern: RegExp,
+  mapper: (match: RegExpExecArray) => AssistantRenderSegment | null,
+): AssistantRenderSegment[] {
+  return input.flatMap((segment) => {
+    if (segment.type !== "markdown" || !segment.content) {
+      return [segment];
+    }
+
+    const parts: AssistantRenderSegment[] = [];
+    let lastIndex = 0;
+    pattern.lastIndex = 0;
+
+    for (let match = pattern.exec(segment.content); match; match = pattern.exec(segment.content)) {
+      if (match.index > lastIndex) {
+        parts.push({
+          type: "markdown",
+          content: segment.content.slice(lastIndex, match.index),
+        });
+      }
+
+      const mapped = mapper(match);
+      if (mapped) {
+        parts.push(mapped);
+      } else {
+        parts.push({
+          type: "markdown",
+          content: match[0],
+        });
+      }
+
+      lastIndex = match.index + match[0].length;
+    }
+
+    if (lastIndex < segment.content.length) {
+      parts.push({
+        type: "markdown",
+        content: segment.content.slice(lastIndex),
+      });
+    }
+
+    return parts.length > 0 ? parts : [segment];
+  });
+}
+
+function normalizeSegments(segments: AssistantRenderSegment[]): AssistantRenderSegment[] {
+  const merged: AssistantRenderSegment[] = [];
+
+  for (const segment of segments) {
+    if (segment.type === "markdown") {
+      if (!segment.content) continue;
+
+      const prev = merged[merged.length - 1];
+      if (prev?.type === "markdown") {
+        prev.content += segment.content;
+      } else {
+        merged.push({ ...segment });
+      }
+      continue;
+    }
+
+    merged.push(segment);
+  }
+
+  return merged.filter((segment) => segment.type === "widget" || segment.content.trim().length > 0);
+}
+
+export function extractCompatBridgeData(rawContent: string): CompatBridgeData {
+  if (!rawContent) return {};
+
+  const data: CompatBridgeData = {};
+
+  for (
+    let match = COMPAT_DATA_BLOCK_RE.exec(rawContent);
+    match;
+    match = COMPAT_DATA_BLOCK_RE.exec(rawContent)
+  ) {
+    const key = match[1].toLowerCase();
+    const value = tryParseStructuredValue(match[2] ?? "");
+
+    if (key === "variableinsert") {
+      data.variableInsert = value;
+      if (data.statWithoutMeta === undefined) {
+        data.statWithoutMeta = value;
+      }
+    } else if (key === "era_data") {
+      data.eraData = value;
+    }
+  }
+
+  return data;
+}
+
+export function extractAssistantRenderSegments(content: string): AssistantRenderSegment[] {
+  if (!content) return [];
+
+  let segments: AssistantRenderSegment[] = [{ type: "markdown", content }];
+
+  segments = splitByPattern(segments, FENCED_BLOCK_RE, (match) => {
+    const inner = (match[1] ?? "").trim();
+    if (!looksLikeWidgetDocument(inner)) return null;
+    return { type: "widget", html: inner };
+  });
+
+  segments = splitByPattern(segments, RAW_DOCUMENT_RE, (match) => {
+    const html = match[0].trim();
+    if (!looksLikeWidgetDocument(html)) return null;
+    return { type: "widget", html };
+  });
+
+  return normalizeSegments(segments);
+}

--- a/client/lib/compat/xml-tag-stripper.ts
+++ b/client/lib/compat/xml-tag-stripper.ts
@@ -9,8 +9,17 @@
  * - "remove": remove tags AND inner content (for update/variable blocks)
  */
 
+import { stCompatAllowedTagNameSet } from "@/lib/compat/html-tags";
+
 /** Tags whose content should be completely removed (not displayed) */
-const REMOVE_TAGS_DEFAULT = ["update", "updatevariable"];
+const REMOVE_TAGS_DEFAULT = [
+  "update",
+  "updatevariable",
+  "variableinsert",
+  "variableedit",
+  "variabledelete",
+  "era_data",
+];
 
 /**
  * Strip custom XML-like tags from content.
@@ -44,69 +53,14 @@ export function stripXmlTags(
   }
 
   // Phase 2: Strip remaining custom XML tags, keeping inner content.
-  // Match paired tags like <gametxt>...</gametxt>, <opening>...</opening>, etc.
-  // Excludes standard HTML tags that react-markdown handles.
-  // Uses a conservative approach: only strip tags that look like custom identifiers.
-  const HTML_TAGS = new Set([
-    "a",
-    "abbr",
-    "b",
-    "blockquote",
-    "br",
-    "code",
-    "dd",
-    "del",
-    "details",
-    "div",
-    "dl",
-    "dt",
-    "em",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "hr",
-    "i",
-    "img",
-    "ins",
-    "kbd",
-    "li",
-    "mark",
-    "ol",
-    "p",
-    "pre",
-    "q",
-    "rp",
-    "rt",
-    "ruby",
-    "s",
-    "samp",
-    "small",
-    "span",
-    "strong",
-    "sub",
-    "summary",
-    "sup",
-    "table",
-    "tbody",
-    "td",
-    "tfoot",
-    "th",
-    "thead",
-    "tr",
-    "u",
-    "ul",
-    "var",
-    "wbr",
-  ]);
+  // Allowed HTML tags are preserved intact so the downstream markdown/rehype pipeline
+  // can sanitize and render them consistently.
 
   // Strip paired custom tags: <tag>content</tag> → content
   result = result.replace(
     /<([a-zA-Z][\w-]*)(?:\s[^>]*)?>[\s\S]*?<\/\1>/g,
     (match, tagName: string) => {
-      if (HTML_TAGS.has(tagName.toLowerCase())) return match;
+      if (stCompatAllowedTagNameSet.has(tagName.toLowerCase())) return match;
       // Strip the opening and closing tags, keep content
       const openEnd = match.indexOf(">") + 1;
       const closeStart = match.lastIndexOf("</");
@@ -116,13 +70,13 @@ export function stripXmlTags(
 
   // Strip orphaned opening tags (no matching close): <tag> → ""
   result = result.replace(/<([a-zA-Z][\w-]*)(?:\s[^>]*)?>/g, (match, tagName: string) => {
-    if (HTML_TAGS.has(tagName.toLowerCase())) return match;
+    if (stCompatAllowedTagNameSet.has(tagName.toLowerCase())) return match;
     return "";
   });
 
   // Strip orphaned closing tags: </tag> → ""
   result = result.replace(/<\/([a-zA-Z][\w-]*)>/g, (match, tagName: string) => {
-    if (HTML_TAGS.has(tagName.toLowerCase())) return match;
+    if (stCompatAllowedTagNameSet.has(tagName.toLowerCase())) return match;
     return "";
   });
 

--- a/client/stores/regex-store.ts
+++ b/client/stores/regex-store.ts
@@ -11,6 +11,7 @@ interface RegexState {
   characterScripts: RegexScriptData[];
   scope: RegexScope;
   loading: boolean;
+  loadedGlobalScripts: boolean;
 
   setScope: (scope: RegexScope) => void;
   fetchGlobalScripts: () => Promise<void>;
@@ -35,6 +36,7 @@ export const useRegexStore = create<RegexState>()((set, get) => ({
   characterScripts: [],
   scope: "global" as RegexScope,
   loading: false,
+  loadedGlobalScripts: false,
 
   setScope: (scope) => set({ scope }),
 
@@ -43,9 +45,9 @@ export const useRegexStore = create<RegexState>()((set, get) => ({
     try {
       const raw = await settingsApi.get(SETTINGS_KEY);
       const scripts = Array.isArray(raw) ? ensureIds(raw as RegexScriptData[]) : [];
-      set({ globalScripts: scripts });
+      set({ globalScripts: scripts, loadedGlobalScripts: true });
     } catch {
-      set({ globalScripts: [] });
+      set({ globalScripts: [], loadedGlobalScripts: true });
     } finally {
       set({ loading: false });
     }


### PR DESCRIPTION
## 目的
统一 assistant 消息的展示前处理逻辑，减少 `MessageBubble` 与 compat iframe 视图后续继续分叉的风险；同时补齐 compat XML/tag 规则的直接测试保护。

## 变更内容
- 抽出共享的 message view-model helper，统一产出 `display`、`scripts`、`thinking`、`segments`、`compatData`、`reasoningDisplay`、`hasWidgets`
- 让消息气泡组件改为消费共享 helper，只保留 UI 层差异
- 补充 compat XML tag 处理规则：移除 `VariableInsert` / `VariableEdit` / `VariableDelete` / `era_data` 内容块
- 保留 `<style>` 作为允许标签的一部分
- 补充 `xml-tag-stripper` 直接测试，覆盖新增规则和允许标签保留

## 接口与兼容性
- 不新增对外 API
- 不修改 iframe RPC 协议
- 不改变现有消息渲染语义，仅去重和加固

## 验证
- `pnpm --filter @arctravern/client exec vp test run lib/compat/__tests__/preprocessor.test.ts lib/compat/__tests__/widget-pipeline.test.ts lib/compat/__tests__/xml-tag-stripper.test.ts`
- 相关 compat 测试通过
