### PR TITLE
feat(compat): 增加运行时清单与世界书语义

### DIFF
--- a/client/components/character/character-editor.tsx
+++ b/client/components/character/character-editor.tsx
@@ -7,6 +7,7 @@ import { useCharacterStore } from "@/stores/character-store";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import type { RuntimeAdapter, RuntimeManifest, RuntimeMode } from "@/lib/compat/runtime-manifest";
 
 type Tab = "basic" | "advanced" | "book";
 
@@ -44,6 +45,40 @@ export function CharacterEditor({ character }: CharacterEditorProps) {
   }
 
   const patch = (value: Partial<Character>) => setForm((prev) => ({ ...prev, ...value }));
+  const patchRuntimeManifest = (value: Partial<RuntimeManifest>) =>
+    setForm((prev) => {
+      const extensions = prev.extensions ?? {};
+      const runtimeManifest = (extensions.runtimeManifest ?? {
+        runtimeMode: "native" as RuntimeMode,
+        promptCompat: false,
+        renderCompat: false,
+        capabilities: {
+          regex: false,
+          htmlDocument: false,
+          script: false,
+          xmlTags: false,
+          variableInsert: false,
+          eraData: false,
+          placeholder: false,
+          styledHtml: false,
+          cssAnimation: false,
+          externalAsset: false,
+          lorebookRegex: false,
+        },
+        detectedFeatures: [],
+      }) as RuntimeManifest;
+
+      return {
+        ...prev,
+        extensions: {
+          ...extensions,
+          runtimeManifest: {
+            ...runtimeManifest,
+            ...value,
+          },
+        },
+      };
+    });
 
   const handleAvatar = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -159,6 +194,50 @@ export function CharacterEditor({ character }: CharacterEditorProps) {
 
       {tab === "advanced" && (
         <div className="flex flex-col gap-1.5">
+          <div className="grid grid-cols-2 gap-2">
+            <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+              Runtime Mode
+              <select
+                value={
+                  ((form.extensions?.runtimeManifest as RuntimeManifest | undefined)?.runtimeMode ??
+                    "native") as RuntimeMode
+                }
+                onChange={(e) =>
+                  patchRuntimeManifest({ runtimeMode: e.target.value as RuntimeMode })
+                }
+                className="h-8 rounded-md border border-input bg-background px-2 text-xs text-foreground"
+              >
+                <option value="native">native</option>
+                <option value="compat-sandbox">compat-sandbox</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+              Runtime Adapter
+              <select
+                value={
+                  ((form.extensions?.runtimeManifest as RuntimeManifest | undefined)?.adapter ??
+                    "st-generic") as RuntimeAdapter
+                }
+                onChange={(e) =>
+                  patchRuntimeManifest({ adapter: e.target.value as RuntimeAdapter })
+                }
+                className="h-8 rounded-md border border-input bg-background px-2 text-xs text-foreground"
+              >
+                <option value="st-generic">st-generic</option>
+                <option value="era">era</option>
+                <option value="fate">fate</option>
+                <option value="custom">custom</option>
+              </select>
+            </label>
+          </div>
+          {(form.extensions?.runtimeManifest as RuntimeManifest | undefined)?.detectedFeatures
+            ?.length ? (
+            <div className="rounded-md border border-border/70 bg-muted/40 px-2 py-1.5 text-[11px] text-muted-foreground">
+              {(
+                form.extensions?.runtimeManifest as RuntimeManifest | undefined
+              )?.detectedFeatures.join(", ")}
+            </div>
+          ) : null}
           <Textarea
             value={form.systemPrompt ?? ""}
             onChange={(e) => patch({ systemPrompt: e.target.value })}

--- a/client/lib/api/character.ts
+++ b/client/lib/api/character.ts
@@ -1,5 +1,10 @@
 import { getApiBase, request, requestBlob } from "./core/http";
 import { coalesceRaw, fromRaw, parseJson, toRawRecord } from "./shared/raw";
+import type { RuntimeManifest } from "@/lib/compat/runtime-manifest";
+
+export interface CharacterExtensions extends Record<string, unknown> {
+  runtimeManifest?: RuntimeManifest;
+}
 
 export interface Character {
   id: number;
@@ -19,7 +24,7 @@ export interface Character {
   tags: string[];
   spec: string;
   specVersion: string;
-  extensions: Record<string, unknown>;
+  extensions: CharacterExtensions;
   characterBook: Record<string, unknown> | null;
   worldInfoBookId: number | null;
   createdAt: string;
@@ -53,7 +58,7 @@ function mapCharacter(rawInput: unknown): Character {
     tags: parseJson<string[]>(raw.tags ?? "[]", []),
     spec: fromRaw(raw.spec, "chara_card_v2"),
     specVersion: fromRaw(coalesceRaw(raw, "spec_version", "specVersion"), "2.0"),
-    extensions: parseJson<Record<string, unknown>>(raw.extensions ?? "{}", {}),
+    extensions: parseJson<CharacterExtensions>(raw.extensions ?? "{}", {}),
     characterBook: parseJson<Record<string, unknown> | null>(
       coalesceRaw(raw, "character_book", "characterBook") ?? null,
       null,

--- a/client/lib/api/world-info.ts
+++ b/client/lib/api/world-info.ts
@@ -42,6 +42,7 @@ export interface WorldInfoEntry {
   sticky: number;
   cooldown: number;
   delay: number;
+  useRegex: boolean;
   vectorized: boolean;
   contentHash: string;
 }
@@ -104,6 +105,7 @@ function mapWorldInfoEntry(rawInput: unknown): WorldInfoEntry {
     sticky: Number(raw.sticky ?? 0),
     cooldown: Number(raw.cooldown ?? 0),
     delay: Number(raw.delay ?? 0),
+    useRegex: Boolean(coalesceRaw(raw, "use_regex", "useRegex")),
     vectorized: Number(coalesceRaw(raw, "vectorized") ?? 0) === 1,
     contentHash: fromRaw(coalesceRaw(raw, "content_hash", "contentHash"), ""),
   };
@@ -140,6 +142,7 @@ export const worldInfoApi = {
     if (data.keys) payload.keys = JSON.stringify(data.keys);
     if (data.secondaryKeys) payload.secondary_keys = JSON.stringify(data.secondaryKeys);
     if (data.vectorized !== undefined) payload.vectorized = data.vectorized ? 1 : 0;
+    if (data.useRegex !== undefined) payload.use_regex = data.useRegex ? 1 : 0;
     return mapWorldInfoEntry(
       await request<unknown>(`/world-info/${bookId}/entries`, {
         method: "POST",
@@ -171,6 +174,7 @@ export const worldInfoApi = {
     if (data.sticky !== undefined) payload.sticky = data.sticky;
     if (data.cooldown !== undefined) payload.cooldown = data.cooldown;
     if (data.delay !== undefined) payload.delay = data.delay;
+    if (data.useRegex !== undefined) payload.useRegex = data.useRegex ? 1 : 0;
     if (data.vectorized !== undefined) payload.vectorized = data.vectorized ? 1 : 0;
     return mapWorldInfoEntry(
       await request<unknown>(`/world-info/entries/${entryId}`, {

--- a/client/lib/compat/runtime-manifest.ts
+++ b/client/lib/compat/runtime-manifest.ts
@@ -1,0 +1,25 @@
+export type RuntimeMode = "native" | "compat-sandbox";
+export type RuntimeAdapter = "st-generic" | "era" | "fate" | "custom";
+
+export interface RuntimeCapabilities {
+  regex: boolean;
+  htmlDocument: boolean;
+  script: boolean;
+  xmlTags: boolean;
+  variableInsert: boolean;
+  eraData: boolean;
+  placeholder: boolean;
+  styledHtml: boolean;
+  cssAnimation: boolean;
+  externalAsset: boolean;
+  lorebookRegex: boolean;
+}
+
+export interface RuntimeManifest {
+  runtimeMode: RuntimeMode;
+  adapter?: RuntimeAdapter;
+  promptCompat: boolean;
+  renderCompat: boolean;
+  capabilities: RuntimeCapabilities;
+  detectedFeatures: string[];
+}

--- a/client/stores/__tests__/world-info-store.test.ts
+++ b/client/stores/__tests__/world-info-store.test.ts
@@ -75,6 +75,7 @@ function createEntryFixture(
     sticky: 0,
     cooldown: 0,
     delay: 0,
+    useRegex: false,
     vectorized: false,
     contentHash: "",
     ...patch,

--- a/server/src/db/drizzle.service.ts
+++ b/server/src/db/drizzle.service.ts
@@ -96,6 +96,7 @@ export class DrizzleService implements OnModuleInit, OnModuleDestroy {
       ['cooldown', 'INTEGER DEFAULT 0'],
       ['delay', 'INTEGER DEFAULT 0'],
       ['triggers', "TEXT DEFAULT '[]'"],
+      ['use_regex', 'INTEGER DEFAULT 0'],
       // ST 1.16+ compatibility fields
       ['vectorized', 'INTEGER DEFAULT 0'],
       ['ignore_budget', 'INTEGER DEFAULT 0'],

--- a/server/src/db/schema-ddl.ts
+++ b/server/src/db/schema-ddl.ts
@@ -115,6 +115,7 @@ export const SCHEMA_DDL = `
     cooldown INTEGER DEFAULT 0,
     delay INTEGER DEFAULT 0,
     triggers TEXT DEFAULT '[]',
+    use_regex INTEGER DEFAULT 0,
     vectorized INTEGER DEFAULT 0,
     ignore_budget INTEGER DEFAULT 0,
     match_persona_desc INTEGER DEFAULT 0,

--- a/server/src/modules/character/__tests__/runtime-manifest.spec.ts
+++ b/server/src/modules/character/__tests__/runtime-manifest.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeRuntimeManifest } from '../runtime-manifest';
+import type { TavernCardV2 } from '../character-card-parser.service';
+
+function makeCard(overrides: Partial<TavernCardV2['data']> = {}): TavernCardV2 {
+  return {
+    spec: 'chara_card_v2',
+    spec_version: '2.0',
+    data: {
+      name: 'Test',
+      description: '',
+      personality: '',
+      scenario: '',
+      first_mes: '',
+      mes_example: '',
+      creator_notes: '',
+      creator: '',
+      character_version: '',
+      tags: [],
+      system_prompt: '',
+      post_history_instructions: '',
+      alternate_greetings: [],
+      extensions: {
+        talkativeness: 0.5,
+        fav: false,
+        world: '',
+        depth_prompt: {
+          prompt: '',
+          depth: 4,
+          role: 'system',
+        },
+      },
+      character_book: null,
+      ...overrides,
+    },
+  };
+}
+
+describe('analyzeRuntimeManifest', () => {
+  it('keeps plain text cards on native runtime', () => {
+    const manifest = analyzeRuntimeManifest(makeCard({ first_mes: 'Hello there.' }));
+
+    expect(manifest.runtimeMode).toBe('native');
+    expect(manifest.promptCompat).toBe(false);
+    expect(manifest.renderCompat).toBe(false);
+  });
+
+  it('classifies ERA cards into compat sandbox', () => {
+    const manifest = analyzeRuntimeManifest(
+      makeCard({
+        first_mes: '<VariableInsert>{"player":{"name":"<user>"}}</VariableInsert>',
+        extensions: {
+          talkativeness: 0.5,
+          fav: false,
+          world: '',
+          depth_prompt: { prompt: '', depth: 4, role: 'system' },
+          regex_scripts: [
+            {
+              scriptName: 'status',
+              findRegex: '/<StatusPlaceHolderImpl\\/>/g',
+              replaceString: '```html\n<!DOCTYPE html><html><body>status</body></html>\n```',
+              placement: [2],
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(manifest.runtimeMode).toBe('compat-sandbox');
+    expect(manifest.adapter).toBe('era');
+    expect(manifest.promptCompat).toBe(true);
+    expect(manifest.renderCompat).toBe(true);
+  });
+
+  it('classifies Fate cards by regex-driven render and lorebook regex conditions', () => {
+    const manifest = analyzeRuntimeManifest(
+      makeCard({
+        extensions: {
+          talkativeness: 0.5,
+          fav: false,
+          world: '',
+          depth_prompt: { prompt: '', depth: 4, role: 'system' },
+          regex_scripts: [
+            {
+              scriptName: 'opening',
+              findRegex: '/<opening>([\\s\\S]*?)<\\/opening>/gi',
+              replaceString: '<div style="color:red">$1</div>',
+              placement: [2],
+            },
+          ],
+        },
+        character_book: {
+          name: 'Fate',
+          entries: [
+            {
+              keys: ['Saber'],
+              secondary_keys: ['/20[0-4][0-9]年/'],
+              selective: true,
+              content: '<Sabercharacter>...</Sabercharacter>',
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(manifest.runtimeMode).toBe('compat-sandbox');
+    expect(manifest.adapter).toBe('fate');
+    expect(manifest.promptCompat).toBe(true);
+    expect(manifest.renderCompat).toBe(true);
+    expect(manifest.capabilities.lorebookRegex).toBe(true);
+  });
+});

--- a/server/src/modules/character/character.controller.ts
+++ b/server/src/modules/character/character.controller.ts
@@ -21,6 +21,7 @@ import path from 'path';
 import YAML from 'yaml';
 import { CharacterService } from './character.service';
 import { CharacterCardParserService, TavernCardV2 } from './character-card-parser.service';
+import { analyzeRuntimeManifest } from './runtime-manifest';
 import { WorldInfoService } from '../world-info/world-info.service';
 
 interface UploadedBinaryFile {
@@ -100,6 +101,7 @@ export class CharacterController {
             sticky: e.sticky,
             cooldown: e.cooldown,
             delay: e.delay,
+            use_regex: Boolean(e.use_regex),
           })),
         };
       }
@@ -145,7 +147,70 @@ export class CharacterController {
     }
   }
 
+  private buildRuntimeManifestCard(character: Awaited<ReturnType<CharacterService['findOne']>>) {
+    if (!character) return null;
+
+    const extensions = this.safeJsonParse<Record<string, unknown>>(character.extensions, {});
+    const characterBook = this.safeJsonParse<Record<string, unknown> | null>(
+      character.character_book,
+      null,
+    );
+
+    return {
+      spec: 'chara_card_v2' as const,
+      spec_version: '2.0' as const,
+      data: {
+        name: character.name,
+        description: character.description,
+        personality: character.personality,
+        scenario: character.scenario,
+        first_mes: character.first_mes,
+        mes_example: character.mes_example,
+        creator_notes: character.creator_notes,
+        creator: character.creator,
+        character_version: character.character_version ?? '',
+        tags: this.safeJsonParse<string[]>(character.tags, []),
+        system_prompt: character.system_prompt,
+        post_history_instructions: character.post_history_instructions,
+        alternate_greetings: this.safeJsonParse<string[]>(character.alternate_greetings, []),
+        extensions,
+        character_book: characterBook,
+      },
+    };
+  }
+
+  private async ensureRuntimeManifest<T extends Awaited<ReturnType<CharacterService['findOne']>>>(
+    character: T,
+  ): Promise<T> {
+    if (!character) return character;
+
+    const extensions = this.safeJsonParse<Record<string, unknown>>(character.extensions, {});
+    if (extensions.runtimeManifest) return character;
+
+    const runtimeCard = this.buildRuntimeManifestCard(character);
+    if (!runtimeCard) return character;
+
+    const nextExtensions = {
+      ...extensions,
+      runtimeManifest: analyzeRuntimeManifest(runtimeCard),
+    };
+
+    await this.characterService.update(character.id, {
+      extensions: JSON.stringify(nextExtensions),
+    });
+
+    return {
+      ...character,
+      extensions: JSON.stringify(nextExtensions),
+    } as T;
+  }
+
   private fromCard(card: TavernCardV2) {
+    const extensions = {
+      ...card.data.extensions,
+      runtimeManifest: analyzeRuntimeManifest(card),
+    };
+
     return {
       name: card.data.name,
       description: card.data.description,
@@ -160,7 +225,7 @@ export class CharacterController {
       creatorNotes: card.data.creator_notes,
       characterVersion: card.data.character_version,
       tags: JSON.stringify(card.data.tags ?? []),
-      extensions: JSON.stringify(card.data.extensions ?? {}),
+      extensions: JSON.stringify(extensions),
       characterBook: card.data.character_book ? JSON.stringify(card.data.character_book) : null,
       spec: card.spec,
       specVersion: card.spec_version,
@@ -169,14 +234,15 @@ export class CharacterController {
 
   @Get()
   async findAll() {
-    return this.characterService.findAll();
+    const characters = await this.characterService.findAll();
+    return Promise.all(characters.map((character) => this.ensureRuntimeManifest(character)));
   }
 
   @Get(':id')
   async findOne(@Param('id', ParseIntPipe) id: number) {
     const character = await this.characterService.findOne(id);
     if (!character) throw new NotFoundException('Character not found');
-    return character;
+    return this.ensureRuntimeManifest(character);
   }
 
   @Get(':id/avatar')

--- a/server/src/modules/character/runtime-manifest.ts
+++ b/server/src/modules/character/runtime-manifest.ts
@@ -1,0 +1,211 @@
+import type { TavernCardV2 } from './character-card-parser.service';
+
+export type RuntimeMode = 'native' | 'compat-sandbox';
+export type RuntimeAdapter = 'st-generic' | 'era' | 'fate' | 'custom';
+
+export interface RuntimeCapabilities {
+  regex: boolean;
+  htmlDocument: boolean;
+  script: boolean;
+  xmlTags: boolean;
+  variableInsert: boolean;
+  eraData: boolean;
+  placeholder: boolean;
+  styledHtml: boolean;
+  cssAnimation: boolean;
+  externalAsset: boolean;
+  lorebookRegex: boolean;
+}
+
+export interface RuntimeManifest {
+  runtimeMode: RuntimeMode;
+  adapter?: RuntimeAdapter;
+  promptCompat: boolean;
+  renderCompat: boolean;
+  capabilities: RuntimeCapabilities;
+  detectedFeatures: string[];
+}
+
+function getString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function isRegexLikeKey(value: unknown): boolean {
+  return typeof value === 'string' && /^\/.+\/[gimsuy]*$/.test(value.trim());
+}
+
+function entryHasRegex(rawEntry: unknown): boolean {
+  if (!rawEntry || typeof rawEntry !== 'object') return false;
+  const entry = rawEntry as Record<string, unknown>;
+
+  if (entry.use_regex === true || entry.useRegex === true) {
+    return true;
+  }
+
+  const keyLists = [entry.keys, entry.key, entry.secondary_keys, entry.keysecondary];
+  return keyLists.some((list) => {
+    if (Array.isArray(list)) {
+      return list.some(isRegexLikeKey);
+    }
+    return isRegexLikeKey(list);
+  });
+}
+
+function collectCardStrings(card: TavernCardV2): string[] {
+  const values: string[] = [
+    card.data.first_mes,
+    card.data.description,
+    card.data.personality,
+    card.data.scenario,
+    card.data.system_prompt,
+    card.data.post_history_instructions,
+    card.data.mes_example,
+    ...card.data.alternate_greetings,
+  ].filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+
+  const bookEntries = Array.isArray(card.data.character_book?.entries)
+    ? card.data.character_book.entries
+    : [];
+
+  for (const rawEntry of bookEntries) {
+    if (!rawEntry || typeof rawEntry !== 'object') continue;
+    const entry = rawEntry as Record<string, unknown>;
+    for (const key of ['content', 'comment']) {
+      if (typeof entry[key] === 'string' && entry[key].trim().length > 0) {
+        values.push(entry[key]);
+      }
+    }
+  }
+
+  return values;
+}
+
+function collectDetectedFeatures(
+  regexScripts: Array<Record<string, unknown>>,
+  capabilities: RuntimeCapabilities,
+): string[] {
+  const detected: string[] = [];
+
+  if (capabilities.regex) detected.push(`regex_scripts:${regexScripts.length}`);
+  if (capabilities.htmlDocument) detected.push('html_document_output');
+  if (capabilities.script) detected.push('script_blocks');
+  if (capabilities.variableInsert) detected.push('variable_insert');
+  if (capabilities.eraData) detected.push('era_data');
+  if (capabilities.placeholder) detected.push('status_placeholder');
+  if (capabilities.cssAnimation) detected.push('css_animation');
+  if (capabilities.externalAsset) detected.push('external_assets');
+  if (capabilities.lorebookRegex) detected.push('lorebook_regex_keys');
+
+  return detected;
+}
+
+export function analyzeRuntimeManifest(card: TavernCardV2): RuntimeManifest {
+  const extensions =
+    card.data.extensions && typeof card.data.extensions === 'object'
+      ? (card.data.extensions as Record<string, unknown>)
+      : {};
+  const regexScripts = Array.isArray(extensions.regex_scripts)
+    ? (extensions.regex_scripts as Array<Record<string, unknown>>)
+    : [];
+  const cardStrings = collectCardStrings(card);
+  const mergedCardText = cardStrings.join('\n');
+  const lorebookEntries = Array.isArray(card.data.character_book?.entries)
+    ? card.data.character_book.entries
+    : [];
+
+  const hasRegex = regexScripts.length > 0;
+  const regexFindStrings = regexScripts.map((script) => getString(script, 'findRegex'));
+  const regexReplaceStrings = regexScripts.map((script) => getString(script, 'replaceString'));
+  const hasHtmlDocument = regexScripts.some((script) =>
+    /<(?:!doctype\s+html|html|body|head)\b/i.test(getString(script, 'replaceString')),
+  );
+  const hasScript =
+    /<script[\s>]/i.test(mergedCardText) ||
+    regexReplaceStrings.some((value) => /<script[\s>]/i.test(value));
+  const hasVariableInsert = /<variableinsert>/i.test(mergedCardText);
+  const hasEraData = /<era_data>/i.test(mergedCardText);
+  const hasPlaceholder =
+    /<StatusPlaceHolderImpl\s*\/?>/i.test(mergedCardText) ||
+    regexFindStrings.some((value) => /<StatusPlaceHolderImpl/i.test(value));
+  const hasStyledHtml = regexScripts.some((script) =>
+    /style\s*=\s*["']/i.test(getString(script, 'replaceString')),
+  );
+  const hasCssAnimation = regexScripts.some((script) =>
+    /@keyframes\b/i.test(getString(script, 'replaceString')),
+  );
+  const hasExternalAsset =
+    /(?:src|href)\s*=\s*["']https?:\/\//i.test(mergedCardText) ||
+    regexReplaceStrings.some((value) => /(?:src|href)\s*=\s*["']https?:\/\//i.test(value));
+  const hasLorebookRegex = lorebookEntries.some(entryHasRegex);
+
+  const hasEraPatterns =
+    hasVariableInsert ||
+    hasEraData ||
+    hasPlaceholder ||
+    regexScripts.some((script, index) =>
+      /<(?:variable(?:insert|edit|delete|think)|era_data|StatusPlaceHolderImpl)/i.test(
+        `${regexFindStrings[index]} ${regexReplaceStrings[index]}`,
+      ),
+    );
+
+  const hasFatePatterns =
+    /<(?:opening|battle|combat_driver|npc_driver|story_driver|story_engine|world_report|status|affinity)\b/i.test(
+      mergedCardText,
+    ) ||
+    regexScripts.some((script, index) =>
+      /<(?:opening|battle|combat_driver|npc_driver|story_driver|story_engine|world_report|status|affinity)\b/i.test(
+        `${regexFindStrings[index]} ${regexReplaceStrings[index]}`,
+      ),
+    );
+
+  const hasXmlTags =
+    /<(?!\/)(?!html\b|head\b|body\b|div\b|span\b|p\b|br\b|hr\b|font\b|strong\b|em\b|section\b|main\b|article\b|header\b|footer\b|details\b|summary\b|button\b)[a-z][\w:-]*(?:\s[^>]*)?>/i.test(
+      mergedCardText,
+    );
+
+  const capabilities: RuntimeCapabilities = {
+    regex: hasRegex,
+    htmlDocument: hasHtmlDocument,
+    script: hasScript,
+    xmlTags: hasXmlTags,
+    variableInsert: hasVariableInsert,
+    eraData: hasEraData,
+    placeholder: hasPlaceholder,
+    styledHtml: hasStyledHtml,
+    cssAnimation: hasCssAnimation,
+    externalAsset: hasExternalAsset,
+    lorebookRegex: hasLorebookRegex,
+  };
+
+  const promptCompat =
+    hasEraPatterns || hasLorebookRegex || /<%[=_-]?[\s\S]*?%>/i.test(mergedCardText);
+  const renderCompat =
+    hasEraPatterns ||
+    hasFatePatterns ||
+    hasHtmlDocument ||
+    hasScript ||
+    hasCssAnimation ||
+    hasExternalAsset;
+  const runtimeMode: RuntimeMode = promptCompat || renderCompat ? 'compat-sandbox' : 'native';
+
+  let adapter: RuntimeAdapter | undefined;
+  if (runtimeMode === 'compat-sandbox') {
+    if (hasEraPatterns) {
+      adapter = 'era';
+    } else if (hasFatePatterns || hasLorebookRegex) {
+      adapter = 'fate';
+    } else {
+      adapter = 'st-generic';
+    }
+  }
+
+  return {
+    runtimeMode,
+    adapter,
+    promptCompat,
+    renderCompat,
+    capabilities,
+    detectedFeatures: collectDetectedFeatures(regexScripts, capabilities),
+  };
+}

--- a/server/src/modules/world-info/__tests__/world-info-normalizer.spec.ts
+++ b/server/src/modules/world-info/__tests__/world-info-normalizer.spec.ts
@@ -31,6 +31,7 @@ describe('normalizeEntry', () => {
       sticky: 3,
       cooldown: 2,
       delay: 1,
+      useRegex: true,
       vectorized: true,
       ignoreBudget: true,
       matchPersonaDescription: true,
@@ -68,6 +69,7 @@ describe('normalizeEntry', () => {
     expect(result.sticky).toBe(3);
     expect(result.cooldown).toBe(2);
     expect(result.delay).toBe(1);
+    expect(result.use_regex).toBe(1);
     expect(result.vectorized).toBe(1);
     expect(result.ignore_budget).toBe(1);
     expect(result.match_persona_desc).toBe(1);
@@ -99,6 +101,7 @@ describe('normalizeEntry', () => {
     expect(result.position).toBe('before_char');
     expect(result.select_logic).toBe(3);
     expect(result.depth).toBe(8);
+    expect(result.use_regex).toBe(0);
   });
 
   it('handles disable=true → enabled=0', () => {
@@ -118,6 +121,7 @@ describe('normalizeEntry', () => {
     expect(result.enabled).toBe(1);
     expect(result.position).toBe('before_char');
     expect(result.probability).toBe(100);
+    expect(result.use_regex).toBe(0);
     expect(result.vectorized).toBe(0);
     expect(result.character_filter).toBe('{}');
   });

--- a/server/src/modules/world-info/__tests__/world-info-scanner.service.spec.ts
+++ b/server/src/modules/world-info/__tests__/world-info-scanner.service.spec.ts
@@ -43,6 +43,7 @@ function makeEntry(overrides: Partial<WorldInfoEntryRow> = {}): WorldInfoEntryRo
     cooldown: 0,
     delay: 0,
     triggers: '[]',
+    use_regex: 0,
     vectorized: 0,
     ignore_budget: 0,
     match_persona_desc: 0,
@@ -93,9 +94,9 @@ describe('WorldInfoScannerService', () => {
     ];
 
     const match = await scanner.scan(entries, { chatMessages: ['dragon breathes fire'] });
-    expect(match).toHaveLength(1);
-
     const noMatch = await scanner.scan(entries, { chatMessages: ['dragon sleeps'] });
+
+    expect(match).toHaveLength(1);
     expect(noMatch).toHaveLength(0);
   });
 
@@ -110,9 +111,9 @@ describe('WorldInfoScannerService', () => {
     ];
 
     const match = await scanner.scan(entries, { chatMessages: ['a friendly dragon'] });
-    expect(match).toHaveLength(1);
-
     const noMatch = await scanner.scan(entries, { chatMessages: ['an evil dragon'] });
+
+    expect(match).toHaveLength(1);
     expect(noMatch).toHaveLength(0);
   });
 
@@ -127,9 +128,9 @@ describe('WorldInfoScannerService', () => {
     ];
 
     const match = await scanner.scan(entries, { chatMessages: ['dragon with fire and ice'] });
-    expect(match).toHaveLength(1);
-
     const noMatch = await scanner.scan(entries, { chatMessages: ['dragon with fire only'] });
+
+    expect(match).toHaveLength(1);
     expect(noMatch).toHaveLength(0);
   });
 
@@ -143,11 +144,10 @@ describe('WorldInfoScannerService', () => {
       }),
     ];
 
-    // NOT_ALL: activates when NOT all secondary keys match
     const match = await scanner.scan(entries, { chatMessages: ['dragon with fire only'] });
-    expect(match).toHaveLength(1);
-
     const noMatch = await scanner.scan(entries, { chatMessages: ['dragon with fire and ice'] });
+
+    expect(match).toHaveLength(1);
     expect(noMatch).toHaveLength(0);
   });
 
@@ -170,14 +170,53 @@ describe('WorldInfoScannerService', () => {
     expect(result[1].content).toBe('second');
   });
 
-  it('scans character description for keywords', async () => {
-    const entries = [makeEntry({ keys: '["warrior"]' })];
+  it('scans character description when the entry enables that source', async () => {
+    const entries = [makeEntry({ keys: '["warrior"]', match_char_desc: 1 })];
     const result = await scanner.scan(entries, {
       chatMessages: ['hello'],
       characterDescription: 'A brave warrior',
     });
 
     expect(result).toHaveLength(1);
+  });
+
+  it('does not scan character description unless the entry enables that source', async () => {
+    const entries = [makeEntry({ keys: '["warrior"]', match_char_desc: 0 })];
+    const result = await scanner.scan(entries, {
+      chatMessages: ['hello'],
+      characterDescription: 'A brave warrior',
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('supports regex-like secondary keys without explicit use_regex', async () => {
+    const entries = [
+      makeEntry({
+        keys: '["Saber"]',
+        selective: 1,
+        secondary_keys: '["/20[0-4][0-9]年/"]',
+        select_logic: SelectLogic.AND_ANY,
+      }),
+    ];
+
+    const match = await scanner.scan(entries, { chatMessages: ['Saber 出现在 2004年 的冬木市'] });
+    const noMatch = await scanner.scan(entries, { chatMessages: ['Saber 出现在 1994年 的冬木市'] });
+
+    expect(match).toHaveLength(1);
+    expect(noMatch).toHaveLength(0);
+  });
+
+  it('supports explicit use_regex for primary keys', async () => {
+    const entries = [
+      makeEntry({
+        keys: '["dragon|wyrm"]',
+        use_regex: 1,
+      }),
+    ];
+
+    const match = await scanner.scan(entries, { chatMessages: ['The wyrm wakes.'] });
+    expect(match).toHaveLength(1);
   });
 
   it('handles disabled entries', async () => {

--- a/server/src/modules/world-info/__tests__/world-info-vector.service.spec.ts
+++ b/server/src/modules/world-info/__tests__/world-info-vector.service.spec.ts
@@ -46,6 +46,7 @@ function makeRow(overrides: Partial<WorldInfoEntryRow> = {}): WorldInfoEntryRow 
     cooldown: 0,
     delay: 0,
     triggers: '[]',
+    use_regex: 0,
     vectorized: 1,
     ignore_budget: 0,
     match_persona_desc: 0,

--- a/server/src/modules/world-info/world-info-normalizer.ts
+++ b/server/src/modules/world-info/world-info-normalizer.ts
@@ -41,6 +41,7 @@ export interface NormalizedWIEntry {
   cooldown: number;
   delay: number;
   triggers: string;
+  use_regex: number;
   vectorized: number;
   ignore_budget: number;
   match_persona_desc: number;
@@ -113,6 +114,10 @@ function toInt(val: unknown, fallback: number): number {
   return fallback;
 }
 
+function toSafeString(val: unknown, fallback = ''): string {
+  return typeof val === 'string' ? val : fallback;
+}
+
 /**
  * Normalize a single entry from any ST-compatible format into DB-ready shape.
  * Handles both character_book V2 field names and ST internal field names.
@@ -128,8 +133,8 @@ export function normalizeEntry(e: Record<string, unknown>): NormalizedWIEntry {
   return {
     keys: toJsonArray(e.keys ?? e.key),
     secondary_keys: toJsonArray(e.secondary_keys ?? e.keysecondary),
-    content: String(e.content ?? ''),
-    comment: String(e.comment ?? e.name ?? ''),
+    content: toSafeString(e.content),
+    comment: toSafeString(e.comment, toSafeString(e.name)),
     enabled:
       e.enabled === false || e.disable === true
         ? 0
@@ -155,18 +160,19 @@ export function normalizeEntry(e: Record<string, unknown>): NormalizedWIEntry {
           ? toBool(e.useProbability)
           : 1,
     depth: toInt(e.depth, 4),
-    group_name: String(e.group_name ?? e.group ?? ''),
+    group_name: toSafeString(e.group_name, toSafeString(e.group)),
     group_override: toBool(e.group_override ?? e.groupOverride),
     group_weight: toInt(e.group_weight ?? e.groupWeight, 100),
     scan_depth: toInt(e.scan_depth ?? e.scanDepth, 0),
     match_whole_words: toBool(e.match_whole_words ?? e.matchWholeWords),
     use_group_scoring: toBool(e.use_group_scoring ?? e.useGroupScoring),
-    automation_id: String(e.automation_id ?? e.automationId ?? ''),
+    automation_id: toSafeString(e.automation_id, toSafeString(e.automationId)),
     role: toInt(e.role, 0),
     sticky: toInt(e.sticky, 0),
     cooldown: toInt(e.cooldown, 0),
     delay: toInt(e.delay, 0),
     triggers: toJsonArray(e.triggers),
+    use_regex: toBool(e.use_regex ?? e.useRegex),
     vectorized: toBool(e.vectorized),
     ignore_budget: toBool(e.ignore_budget ?? e.ignoreBudget),
     match_persona_desc: toBool(e.match_persona_desc ?? e.matchPersonaDescription),

--- a/server/src/modules/world-info/world-info-scanner.service.ts
+++ b/server/src/modules/world-info/world-info-scanner.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import type { WorldInfoVectorService, WIEmbeddingSettings } from './world-info-vector.service';
 import type { WorldInfoEntryRow } from './world-info.service';
 
-/** Select logic enum matching SillyTavern */
 export enum SelectLogic {
   AND_ANY = 0,
   NOT_ALL = 1,
@@ -10,7 +9,6 @@ export enum SelectLogic {
   AND_ALL = 3,
 }
 
-/** Position enum */
 export enum WIPosition {
   BEFORE_CHAR = 'before_char',
   AFTER_CHAR = 'after_char',
@@ -21,7 +19,6 @@ export enum WIPosition {
   AFTER_AUTHOR_NOTE = 'after_an',
 }
 
-/** Role mapping */
 export enum WIRole {
   SYSTEM = 0,
   USER = 1,
@@ -57,7 +54,6 @@ export interface ScanSettings {
 
 @Injectable()
 export class WorldInfoScannerService {
-  /** Keyword path: non-vectorized always; vectorized only when hybrid or constant. */
   private isKeywordScannedEntry(entry: WorldInfoEntryRow, hybrid: boolean): boolean {
     if (entry.constant) return true;
     if (!entry.vectorized) return true;
@@ -93,67 +89,70 @@ export class WorldInfoScannerService {
     vectorService?: WorldInfoVectorService,
     wiEmbedding?: WIEmbeddingSettings,
   ): Promise<ActivatedEntry[]> {
-    const scanDepth = settings.scanDepth ?? 50;
     const maxRecursion = settings.maxRecursionSteps ?? 3;
     const enableRecursion = settings.recursion ?? true;
     const hybrid = wiEmbedding?.hybridMode ?? false;
 
-    // Build scan buffer
-    const recentMessages = context.chatMessages.slice(-scanDepth);
-    let scanBuffer = recentMessages.join('\n');
-    if (context.characterDescription) scanBuffer += '\n' + context.characterDescription;
-    if (context.characterPersonality) scanBuffer += '\n' + context.characterPersonality;
-    if (context.personaDescription) scanBuffer += '\n' + context.personaDescription;
-    if (context.scenario) scanBuffer += '\n' + context.scenario;
-
-    const enabledEntries = entries.filter((e) => e.enabled);
+    const enabledEntries = entries.filter((entry) => entry.enabled);
     const activatedIds = new Set<number>();
     const activated: ActivatedEntry[] = [];
 
-    const keywordEntries = enabledEntries.filter((e) => this.isKeywordScannedEntry(e, hybrid));
+    const keywordEntries = enabledEntries.filter((entry) =>
+      this.isKeywordScannedEntry(entry, hybrid),
+    );
+    this.scanRound(keywordEntries, context, settings, activatedIds, activated);
 
-    // Initial keyword scan
-    this.scanRound(keywordEntries, scanBuffer, activatedIds, activated);
-
-    // Vector scan (single embed over scan buffer, before recursion)
-    const vectorEntries = enabledEntries.filter((e) => e.vectorized);
+    const vectorEntries = enabledEntries.filter((entry) => entry.vectorized);
     if (vectorEntries.length > 0 && vectorService && wiEmbedding) {
+      const vectorBuffer = this.buildScanBuffer(
+        undefined,
+        context,
+        settings.scanDepth ?? 50,
+        false,
+      );
+
       try {
         await this.scanVectorized(
           vectorEntries,
           entries,
-          scanBuffer,
+          vectorBuffer,
           activatedIds,
           activated,
           vectorService,
           wiEmbedding,
         );
       } catch {
-        // Vector search failed — fall back to keyword matching for vectorized entries
-        this.scanRound(vectorEntries, scanBuffer, activatedIds, activated);
+        this.scanRound(vectorEntries, context, settings, activatedIds, activated);
       }
     }
 
-    // Recursive keyword scans
     if (enableRecursion) {
-      for (let step = 0; step < maxRecursion; step++) {
+      for (let step = 0; step < maxRecursion; step += 1) {
         const newEntries = enabledEntries.filter(
-          (e) =>
-            !activatedIds.has(e.id) &&
-            !e.exclude_recursion &&
-            this.isKeywordScannedEntry(e, hybrid),
+          (entry) =>
+            !activatedIds.has(entry.id) &&
+            !entry.exclude_recursion &&
+            this.isKeywordScannedEntry(entry, hybrid),
         );
         if (newEntries.length === 0) break;
 
         const recursionBuffer = activated
-          .filter((a) => !entries.find((e) => e.id === a.id)?.prevent_recursion)
-          .map((a) => a.content)
+          .filter((item) => !entries.find((entry) => entry.id === item.id)?.prevent_recursion)
+          .map((item) => item.content)
           .join('\n');
-
         if (!recursionBuffer.trim()) break;
 
         const beforeCount = activated.length;
-        this.scanRound(newEntries, scanBuffer + '\n' + recursionBuffer, activatedIds, activated);
+        this.scanRound(
+          newEntries,
+          {
+            ...context,
+            chatMessages: [...context.chatMessages, recursionBuffer],
+          },
+          settings,
+          activatedIds,
+          activated,
+        );
         if (activated.length === beforeCount) break;
       }
     }
@@ -172,7 +171,7 @@ export class WorldInfoScannerService {
     vectorService: WorldInfoVectorService,
     wiEmbedding: WIEmbeddingSettings,
   ): Promise<void> {
-    const bookIds = [...new Set(vectorEntries.map((e) => e.book_id))];
+    const bookIds = [...new Set(vectorEntries.map((entry) => entry.book_id))];
     const query = scanBuffer.slice(0, 4000);
     const hits = await vectorService.searchEntries(
       query,
@@ -180,7 +179,8 @@ export class WorldInfoScannerService {
       wiEmbedding,
       vectorEntries.length,
     );
-    const byId = new Map(allEntries.map((e) => [e.id, e]));
+    const byId = new Map(allEntries.map((entry) => [entry.id, entry]));
+
     for (const hit of hits) {
       if (activatedIds.has(hit.entryId)) continue;
       const entry = byId.get(hit.entryId);
@@ -193,35 +193,27 @@ export class WorldInfoScannerService {
 
   private scanRound(
     entries: WorldInfoEntryRow[],
-    buffer: string,
+    context: ScanContext,
+    settings: ScanSettings,
     activatedIds: Set<number>,
     activated: ActivatedEntry[],
   ): void {
     for (const entry of entries) {
       if (activatedIds.has(entry.id)) continue;
+      if (!this.shouldActivate(entry, context, settings)) continue;
 
-      if (this.shouldActivate(entry, buffer)) {
-        activatedIds.add(entry.id);
-        activated.push({
-          id: entry.id,
-          uid: entry.uid,
-          content: entry.content,
-          position: entry.position,
-          order: entry.insertion_order,
-          depth: entry.depth,
-          role: entry.role,
-          groupName: entry.group_name ?? '',
-          groupWeight: entry.group_weight ?? 100,
-        });
-      }
+      activatedIds.add(entry.id);
+      activated.push(this.entryToActivated(entry));
     }
   }
 
-  private shouldActivate(entry: WorldInfoEntryRow, buffer: string): boolean {
-    // Constant entries always activate
+  private shouldActivate(
+    entry: WorldInfoEntryRow,
+    context: ScanContext,
+    settings: ScanSettings,
+  ): boolean {
     if (entry.constant) return true;
 
-    // Probability check
     if (entry.use_probability && entry.probability < 100) {
       if (Math.random() * 100 >= entry.probability) return false;
     }
@@ -229,90 +221,130 @@ export class WorldInfoScannerService {
     const primaryKeys = this.parseKeys(entry.keys);
     if (primaryKeys.length === 0) return false;
 
-    const caseSensitive = Boolean(entry.case_sensitive);
+    const caseSensitive = Boolean(entry.case_sensitive || settings.caseSensitive);
     const matchWholeWords = Boolean(entry.match_whole_words);
+    const buffer = this.buildScanBuffer(entry, context, settings.scanDepth ?? 50);
     const searchBuffer = caseSensitive ? buffer : buffer.toLowerCase();
 
-    const primaryMatch = this.matchKeys(primaryKeys, searchBuffer, caseSensitive, matchWholeWords);
+    const primaryMatch = this.matchKeys(
+      entry,
+      primaryKeys,
+      searchBuffer,
+      caseSensitive,
+      matchWholeWords,
+    );
     if (!primaryMatch) return false;
 
-    // If selective, check secondary keys
-    if (entry.selective) {
-      const secondaryKeys = this.parseKeys(entry.secondary_keys);
-      if (secondaryKeys.length === 0) return true;
+    if (!entry.selective) return true;
 
-      const secondaryMatch = this.matchKeys(
-        secondaryKeys,
-        searchBuffer,
-        caseSensitive,
-        matchWholeWords,
-      );
-      const logic = entry.select_logic ?? SelectLogic.AND_ANY;
+    const secondaryKeys = this.parseKeys(entry.secondary_keys);
+    if (secondaryKeys.length === 0) return true;
 
-      switch (logic) {
-        case SelectLogic.AND_ANY:
-          return primaryMatch && secondaryMatch;
-        case SelectLogic.NOT_ALL:
-          return (
-            primaryMatch &&
-            !this.matchAllKeys(secondaryKeys, searchBuffer, caseSensitive, matchWholeWords)
-          );
-        case SelectLogic.NOT_ANY:
-          return primaryMatch && !secondaryMatch;
-        case SelectLogic.AND_ALL:
-          return (
-            primaryMatch &&
-            this.matchAllKeys(secondaryKeys, searchBuffer, caseSensitive, matchWholeWords)
-          );
-        default:
-          return primaryMatch && secondaryMatch;
+    const secondaryMatch = this.matchKeys(
+      entry,
+      secondaryKeys,
+      searchBuffer,
+      caseSensitive,
+      matchWholeWords,
+    );
+    const logic = entry.select_logic ?? SelectLogic.AND_ANY;
+
+    switch (logic) {
+      case SelectLogic.AND_ANY:
+        return primaryMatch && secondaryMatch;
+      case SelectLogic.NOT_ALL:
+        return (
+          primaryMatch &&
+          !this.matchAllKeys(entry, secondaryKeys, searchBuffer, caseSensitive, matchWholeWords)
+        );
+      case SelectLogic.NOT_ANY:
+        return primaryMatch && !secondaryMatch;
+      case SelectLogic.AND_ALL:
+        return (
+          primaryMatch &&
+          this.matchAllKeys(entry, secondaryKeys, searchBuffer, caseSensitive, matchWholeWords)
+        );
+      default:
+        return primaryMatch && secondaryMatch;
+    }
+  }
+
+  private buildScanBuffer(
+    entry: WorldInfoEntryRow | undefined,
+    context: ScanContext,
+    defaultScanDepth: number,
+    includeOptionalContext = true,
+  ): string {
+    const scanDepth = entry && entry.scan_depth > 0 ? entry.scan_depth : defaultScanDepth;
+    const parts = context.chatMessages.slice(-scanDepth);
+
+    if (includeOptionalContext && entry) {
+      if (entry.match_char_desc && context.characterDescription) {
+        parts.push(context.characterDescription);
+      }
+      if (entry.match_char_personality && context.characterPersonality) {
+        parts.push(context.characterPersonality);
+      }
+      if (entry.match_persona_desc && context.personaDescription) {
+        parts.push(context.personaDescription);
+      }
+      if (entry.match_scenario && context.scenario) {
+        parts.push(context.scenario);
       }
     }
 
-    return true;
+    return parts.filter(Boolean).join('\n');
   }
 
   private parseKeys(keysJson: string): string[] {
     try {
       const parsed = JSON.parse(keysJson);
       if (Array.isArray(parsed)) {
-        return parsed.map((k: string) => k.trim()).filter((k: string) => k.length > 0);
+        return parsed.map((key: string) => key.trim()).filter((key: string) => key.length > 0);
       }
       return [];
     } catch {
-      // Try comma-separated fallback
       return keysJson
         .split(',')
-        .map((k) => k.trim())
-        .filter((k) => k.length > 0);
+        .map((key) => key.trim())
+        .filter((key) => key.length > 0);
     }
   }
 
   private matchKeys(
+    entry: WorldInfoEntryRow,
     keys: string[],
     buffer: string,
     caseSensitive: boolean,
     wholeWords: boolean,
   ): boolean {
-    return keys.some((key) => this.matchSingleKey(key, buffer, caseSensitive, wholeWords));
+    return keys.some((key) => this.matchSingleKey(entry, key, buffer, caseSensitive, wholeWords));
   }
 
   private matchAllKeys(
+    entry: WorldInfoEntryRow,
     keys: string[],
     buffer: string,
     caseSensitive: boolean,
     wholeWords: boolean,
   ): boolean {
-    return keys.every((key) => this.matchSingleKey(key, buffer, caseSensitive, wholeWords));
+    return keys.every((key) => this.matchSingleKey(entry, key, buffer, caseSensitive, wholeWords));
   }
 
   private matchSingleKey(
+    entry: WorldInfoEntryRow,
     key: string,
     buffer: string,
     caseSensitive: boolean,
     wholeWords: boolean,
   ): boolean {
     const searchKey = caseSensitive ? key : key.toLowerCase();
+    const shouldUseRegex = Boolean(entry.use_regex) || this.isRegexPattern(searchKey);
+
+    if (shouldUseRegex) {
+      const regex = this.regexFromKey(key, caseSensitive);
+      return regex ? regex.test(buffer) : false;
+    }
 
     if (wholeWords) {
       const escaped = searchKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -321,6 +353,31 @@ export class WorldInfoScannerService {
     }
 
     return buffer.includes(searchKey);
+  }
+
+  private isRegexPattern(key: string): boolean {
+    return /^\/.+\/[gimsuy]*$/.test(key.trim());
+  }
+
+  private regexFromKey(key: string, caseSensitive: boolean): RegExp | null {
+    const trimmed = key.trim();
+    const slashMatch = trimmed.match(/^\/(.+)\/([gimsuy]*)$/);
+
+    try {
+      if (slashMatch) {
+        const [, pattern, rawFlags] = slashMatch;
+        const flags = caseSensitive
+          ? rawFlags.replace(/i/g, '')
+          : rawFlags.includes('i')
+            ? rawFlags
+            : `${rawFlags}i`;
+        return new RegExp(pattern, flags);
+      }
+
+      return new RegExp(trimmed, caseSensitive ? '' : 'i');
+    } catch {
+      return null;
+    }
   }
 
   private applyGroupScoring(
@@ -343,30 +400,28 @@ export class WorldInfoScannerService {
     const result: ActivatedEntry[] = [...ungrouped];
 
     for (const [, group] of groupMap) {
-      const entryData = group.map((g) => ({
-        entry: g,
-        source: allEntries.find((e) => e.id === g.id),
+      const entryData = group.map((item) => ({
+        entry: item,
+        source: allEntries.find((entry) => entry.id === item.id),
       }));
 
-      const useGroupScoring = entryData.some((e) => e.source?.use_group_scoring);
-
+      const useGroupScoring = entryData.some((item) => item.source?.use_group_scoring);
       if (useGroupScoring) {
-        // Weighted random selection
-        const totalWeight = group.reduce((sum, g) => sum + g.groupWeight, 0);
+        const totalWeight = group.reduce((sum, item) => sum + item.groupWeight, 0);
         if (totalWeight > 0) {
           let roll = Math.random() * totalWeight;
-          for (const entry of group) {
-            roll -= entry.groupWeight;
+          for (const item of group) {
+            roll -= item.groupWeight;
             if (roll <= 0) {
-              result.push(entry);
+              result.push(item);
               break;
             }
           }
         }
-      } else {
-        // Include all group entries
-        result.push(...group);
+        continue;
       }
+
+      result.push(...group);
     }
 
     return result;

--- a/server/src/modules/world-info/world-info.service.ts
+++ b/server/src/modules/world-info/world-info.service.ts
@@ -45,6 +45,7 @@ export interface WorldInfoEntryRow {
   cooldown: number;
   delay: number;
   triggers: string;
+  use_regex: number;
   // ST 1.16+ compatibility fields
   vectorized: number;
   ignore_budget: number;
@@ -129,11 +130,11 @@ export class WorldInfoService {
         case_sensitive, priority, position, extensions, constant, selective, select_logic,
         "order", exclude_recursion, prevent_recursion, probability, use_probability,
         depth, group_name, group_override, group_weight, scan_depth, match_whole_words,
-        use_group_scoring, automation_id, role, sticky, cooldown, delay, triggers,
+        use_group_scoring, automation_id, role, sticky, cooldown, delay, triggers, use_regex,
         vectorized, ignore_budget, match_persona_desc, match_char_desc,
         match_char_personality, match_scenario, delay_until_recursion, character_filter,
         content_hash
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         bookId,
         uid,
@@ -168,6 +169,7 @@ export class WorldInfoService {
         data.cooldown ?? 0,
         data.delay ?? 0,
         data.triggers ?? '[]',
+        data.use_regex ?? 0,
         data.vectorized ?? 0,
         data.ignore_budget ?? 0,
         data.match_persona_desc ?? 0,
@@ -215,6 +217,7 @@ export class WorldInfoService {
       cooldown: 'cooldown',
       delay: 'delay',
       triggers: 'triggers',
+      useRegex: 'use_regex',
       vectorized: 'vectorized',
       ignoreBudget: 'ignore_budget',
       matchPersonaDesc: 'match_persona_desc',


### PR DESCRIPTION
## 目的
为 compat 运行时补齐角色级运行时清单和世界书语义，让后续 prompt/runtime/sandbox 层有稳定的数据基础。

## 变更内容
- 增加 runtime manifest 的服务端生成与测试
- 在角色相关接口中暴露运行时清单所需字段
- 补充世界书扫描、归一化、服务层的 compat 语义整理
- 让前端 API 与编辑器侧能够读取和使用这些新增语义

## 接口与兼容性
- 新增的是 compat 运行时所需数据面
- 不改变现有聊天协议
- 作为后续 prompt runtime 和 sandbox runtime 的上游依赖层

## 验证
- 包含 runtime manifest 与 world-info 相关测试
- 为后续 stack 层提供稳定基线
