### PR TITLE
feat(server): 增加 compat 提示词运行时

### DIFF
--- a/server/src/modules/chat/__tests__/chat-generation.controller.spec.ts
+++ b/server/src/modules/chat/__tests__/chat-generation.controller.spec.ts
@@ -9,6 +9,7 @@ import type { WorldInfoScannerService } from '../../world-info/world-info-scanne
 import type { WorldInfoVectorService } from '../../world-info/world-info-vector.service';
 import type { PersonaService } from '../../persona/persona.service';
 import type { RagService } from '../../rag/rag.service';
+import type { CompatPromptRuntimeService } from '../compat-prompt-runtime.service';
 
 function makeController() {
   const chatService = {
@@ -25,6 +26,23 @@ function makeController() {
     {} as WorldInfoVectorService,
     {} as PersonaService,
     {} as RagService,
+    {
+      prepare: vi.fn().mockResolvedValue({
+        manifest: null,
+        adapter: null,
+        namespaces: {
+          global: {},
+          chat: {},
+          character: {},
+          session: {},
+        },
+        sessionState: {},
+        eraData: null,
+        messageCompat: {},
+      }),
+      renderCharacter: vi.fn(async (character) => character),
+      renderEntries: vi.fn(async (entries) => entries),
+    } as unknown as CompatPromptRuntimeService,
   );
   return { controller, chatService };
 }

--- a/server/src/modules/chat/__tests__/compat-prompt-runtime.service.spec.ts
+++ b/server/src/modules/chat/__tests__/compat-prompt-runtime.service.spec.ts
@@ -1,0 +1,127 @@
+/// <reference types="vitest/globals" />
+import { CompatPromptRuntimeService } from '../compat-prompt-runtime.service';
+import { createMinimalCharacterRow } from '@/test/fixtures/prompt-builder';
+import type { MessageRow } from '../chat.service';
+
+function makeMessage(overrides: Partial<MessageRow> = {}): MessageRow {
+  return {
+    id: 1,
+    chat_id: 1,
+    role: 'assistant',
+    name: '',
+    content: '',
+    is_hidden: 0,
+    swipe_id: 0,
+    swipes: '[]',
+    gen_started: null,
+    gen_finished: null,
+    extra: '{}',
+    created_at: '',
+    ...overrides,
+  };
+}
+
+describe('CompatPromptRuntimeService', () => {
+  it('extracts VariableInsert state and persists compat session', async () => {
+    const settingsService = {
+      get: vi.fn().mockResolvedValue({}),
+      set: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = new CompatPromptRuntimeService(settingsService as never);
+    const character = createMinimalCharacterRow({
+      extensions: JSON.stringify({
+        runtimeManifest: {
+          runtimeMode: 'compat-sandbox',
+          adapter: 'era',
+          promptCompat: true,
+          renderCompat: true,
+          capabilities: {},
+          detectedFeatures: ['variable_insert'],
+        },
+      }),
+    });
+
+    const context = await service.prepare(character, 7, [
+      makeMessage({
+        content:
+          '<VariableInsert>{"world_state":{"location":"旧校舍"},"player":{"san":80}}</VariableInsert>',
+      }),
+    ]);
+
+    expect(context.adapter).toBe('era');
+    expect(context.sessionState).toEqual({
+      world_state: { location: '旧校舍' },
+      player: { san: 80 },
+    });
+    expect(settingsService.set).toHaveBeenCalledWith(
+      'compat:session:7:1',
+      expect.objectContaining({
+        stat_data: context.sessionState,
+      }),
+    );
+  });
+
+  it('renders ERA EJS-style templates with getvar access', async () => {
+    const settingsService = {
+      get: vi.fn().mockResolvedValue({}),
+      set: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = new CompatPromptRuntimeService(settingsService as never);
+    const character = createMinimalCharacterRow({
+      extensions: JSON.stringify({
+        runtimeManifest: {
+          runtimeMode: 'compat-sandbox',
+          adapter: 'era',
+          promptCompat: true,
+          renderCompat: true,
+          capabilities: {},
+          detectedFeatures: ['variable_insert'],
+        },
+      }),
+    });
+
+    const context = await service.prepare(character, 3, [
+      makeMessage({
+        content: '<VariableInsert>{"world_state":{"location":"旧校舍-3F-女厕所"}}</VariableInsert>',
+      }),
+    ]);
+
+    const rendered = await service.renderContent(
+      "当前位置：<%= await (async () => getvar('stat_data.world_state.location'))() %>",
+      context,
+    );
+
+    expect(rendered).toContain('旧校舍-3F-女厕所');
+  });
+
+  it('expands ERA all-data placeholder from compat session state', async () => {
+    const settingsService = {
+      get: vi.fn().mockResolvedValue({}),
+      set: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = new CompatPromptRuntimeService(settingsService as never);
+    const character = createMinimalCharacterRow({
+      extensions: JSON.stringify({
+        runtimeManifest: {
+          runtimeMode: 'compat-sandbox',
+          adapter: 'era',
+          promptCompat: true,
+          renderCompat: true,
+          capabilities: {},
+          detectedFeatures: ['variable_insert'],
+        },
+      }),
+    });
+
+    const context = await service.prepare(character, 3, [
+      makeMessage({
+        content:
+          '<VariableInsert>{"player":{"name":"<user>"},"world_state":{"location":"旧校舍"}}</VariableInsert>',
+      }),
+    ]);
+
+    const rendered = await service.renderContent('状态:\n{{ERA:$ALLDATA}}', context);
+    expect(rendered).toContain('"player"');
+    expect(rendered).toContain('"world_state"');
+  });
+});

--- a/server/src/modules/chat/chat-generation.controller.ts
+++ b/server/src/modules/chat/chat-generation.controller.ts
@@ -20,6 +20,10 @@ import { WorldInfoScannerService } from '../world-info/world-info-scanner.servic
 import { WorldInfoVectorService } from '../world-info/world-info-vector.service';
 import { PersonaService } from '../persona/persona.service';
 import { RagService } from '../rag/rag.service';
+import {
+  CompatPromptRuntimeService,
+  type CompatPromptContext,
+} from './compat-prompt-runtime.service';
 import type { CompletionRequest, ChatMessage } from '../ai-provider/types';
 import type { RetrievedMemory } from '../rag/types';
 import {
@@ -73,6 +77,7 @@ export class ChatGenerationController {
     private readonly worldInfoVectorService: WorldInfoVectorService,
     private readonly personaService: PersonaService,
     private readonly ragService: RagService,
+    private readonly compatPromptRuntime: CompatPromptRuntimeService,
   ) {}
 
   private chatDebug(event: string, payload?: Record<string, unknown>) {
@@ -167,6 +172,13 @@ export class ChatGenerationController {
       ];
     }
 
+    const personaDescription = await this.getPersonaDescription(body.personaId, character.id);
+    const compatContext = await this.compatPromptRuntime.prepare(character, chat.id, promptSource);
+    const compatCharacter = await this.compatPromptRuntime.renderCharacter(
+      character,
+      compatContext,
+    );
+
     // RAG: retrieve relevant memories
     const ragSettings = await this.ragService.getSettings();
     let ragContext: RetrievedMemory[] = [];
@@ -179,17 +191,19 @@ export class ChatGenerationController {
       );
     }
 
-    const promptMessages = this.promptBuilder.buildPrompt(character, chat, promptSource, {
+    const promptMessages = this.promptBuilder.buildPrompt(compatCharacter, chat, promptSource, {
       maxTokens: body.maxTokens,
       maxContext: body.maxContext,
       userName: body.userName ?? 'User',
       mergeSystemMessages: true,
-      personaDescription: await this.getPersonaDescription(body.personaId, character.id),
+      personaDescription,
       worldInfoSettings: {
         activatedEntries: await this.getActivatedEntries(
           body.worldInfoBookIds,
           promptSource,
-          character,
+          compatCharacter,
+          personaDescription,
+          compatContext,
         ),
       },
       ragContext,
@@ -746,6 +760,8 @@ export class ChatGenerationController {
     bookIds: number[] | undefined,
     messages: MessageRow[],
     character: { description: string; personality: string; scenario: string },
+    personaDescription: string | undefined,
+    compatContext: CompatPromptContext,
   ) {
     if (!bookIds || bookIds.length === 0) return [];
 
@@ -760,17 +776,20 @@ export class ChatGenerationController {
     const hasVectorized = allEntries.some((e) => e.vectorized);
     const wiEmbedding = hasVectorized ? await this.worldInfoVectorService.getSettings() : undefined;
 
-    return this.worldInfoScanner.scan(
+    const activated = await this.worldInfoScanner.scan(
       allEntries,
       {
         chatMessages: messages.map((m) => m.content),
         characterDescription: character.description,
         characterPersonality: character.personality,
+        personaDescription,
         scenario: character.scenario,
       },
       {},
       hasVectorized ? this.worldInfoVectorService : undefined,
       wiEmbedding,
     );
+
+    return this.compatPromptRuntime.renderEntries(activated, compatContext);
   }
 }

--- a/server/src/modules/chat/chat.module.ts
+++ b/server/src/modules/chat/chat.module.ts
@@ -8,11 +8,20 @@ import { AiProviderModule } from '../ai-provider/ai-provider.module';
 import { WorldInfoModule } from '../world-info/world-info.module';
 import { PersonaModule } from '../persona/persona.module';
 import { RagModule } from '../rag/rag.module';
+import { SettingsModule } from '../settings/settings.module';
+import { CompatPromptRuntimeService } from './compat-prompt-runtime.service';
 
 @Module({
-  imports: [CharacterModule, AiProviderModule, WorldInfoModule, PersonaModule, RagModule],
+  imports: [
+    CharacterModule,
+    AiProviderModule,
+    WorldInfoModule,
+    PersonaModule,
+    RagModule,
+    SettingsModule,
+  ],
   controllers: [ChatController, ChatGenerationController],
-  providers: [ChatService, PromptBuilderService],
-  exports: [ChatService, PromptBuilderService],
+  providers: [ChatService, PromptBuilderService, CompatPromptRuntimeService],
+  exports: [ChatService, PromptBuilderService, CompatPromptRuntimeService],
 })
 export class ChatModule {}

--- a/server/src/modules/chat/compat-prompt-runtime.service.ts
+++ b/server/src/modules/chat/compat-prompt-runtime.service.ts
@@ -1,0 +1,369 @@
+import { Injectable } from '@nestjs/common';
+import type { CharacterRow } from '../character/character.service';
+import type { MessageRow } from './chat.service';
+import type { ActivatedEntry } from '../world-info/world-info-scanner.service';
+import type { RuntimeManifest } from '../character/runtime-manifest';
+import { SettingsService } from '../settings/settings.service';
+
+type CompatAdapterId = NonNullable<RuntimeManifest['adapter']>;
+type JsonRecord = Record<string, unknown>;
+
+export interface CompatPromptContext {
+  manifest: RuntimeManifest | null;
+  adapter: CompatAdapterId | null;
+  namespaces: {
+    global: JsonRecord;
+    chat: JsonRecord;
+    character: JsonRecord;
+    session: JsonRecord;
+  };
+  sessionState: JsonRecord;
+  eraData: unknown;
+  messageCompat: JsonRecord;
+}
+
+const VARIABLE_BLOCK_RE =
+  /<(variableinsert|variableedit|variabledelete|era_data)>\s*([\s\S]*?)\s*<\/\1>/gi;
+const ST_COMPAT_VARS_KEY = 'stCompatVars';
+const AsyncFunction = Object.getPrototypeOf(async function () {
+  return undefined;
+}).constructor as new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function deepMerge(target: JsonRecord, source: JsonRecord): JsonRecord {
+  const output: JsonRecord = { ...target };
+
+  for (const [key, value] of Object.entries(source)) {
+    if (isRecord(value) && isRecord(output[key])) {
+      output[key] = deepMerge(output[key] as JsonRecord, value);
+      continue;
+    }
+    output[key] = value;
+  }
+
+  return output;
+}
+
+function getByPath(root: JsonRecord, path: string): unknown {
+  return path.split('.').reduce<unknown>((current, key) => {
+    if (!isRecord(current)) return undefined;
+    return current[key];
+  }, root);
+}
+
+function setByPath(root: JsonRecord, path: string, value: unknown): void {
+  const keys = path.split('.').filter(Boolean);
+  if (keys.length === 0) return;
+
+  let current: JsonRecord = root;
+  for (let index = 0; index < keys.length - 1; index += 1) {
+    const key = keys[index];
+    const next = current[key];
+    if (!isRecord(next)) {
+      current[key] = {};
+    }
+    current = current[key] as JsonRecord;
+  }
+
+  current[keys[keys.length - 1]] = value;
+}
+
+function deleteByPath(root: JsonRecord, path: string): void {
+  const keys = path.split('.').filter(Boolean);
+  if (keys.length === 0) return;
+
+  let current: JsonRecord = root;
+  for (let index = 0; index < keys.length - 1; index += 1) {
+    const next = current[keys[index]];
+    if (!isRecord(next)) return;
+    current = next;
+  }
+
+  delete current[keys[keys.length - 1]];
+}
+
+function parseStructuredValue(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+
+  if (
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  ) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }
+
+  return trimmed;
+}
+
+function extractMessageCompat(messages: MessageRow[]): JsonRecord {
+  const merged: JsonRecord = {};
+
+  for (const message of messages) {
+    if (!message.extra) continue;
+
+    try {
+      const parsed = JSON.parse(message.extra) as JsonRecord;
+      const rawRows = parsed[ST_COMPAT_VARS_KEY];
+      if (!Array.isArray(rawRows)) continue;
+
+      const currentRow = rawRows[message.swipe_id];
+      if (isRecord(currentRow)) {
+        Object.assign(merged, currentRow);
+      }
+    } catch {
+      // ignore malformed compat state in legacy messages
+    }
+  }
+
+  return merged;
+}
+
+function extractManifest(character: CharacterRow): RuntimeManifest | null {
+  try {
+    const extensions = JSON.parse(character.extensions || '{}') as JsonRecord;
+    return isRecord(extensions.runtimeManifest)
+      ? (extensions.runtimeManifest as RuntimeManifest)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+@Injectable()
+export class CompatPromptRuntimeService {
+  constructor(private readonly settingsService: SettingsService) {}
+
+  async prepare(
+    character: CharacterRow,
+    chatId: number,
+    messages: MessageRow[],
+  ): Promise<CompatPromptContext> {
+    const manifest = extractManifest(character);
+    const adapter = manifest?.promptCompat ? (manifest.adapter ?? null) : null;
+
+    const [globalNamespace, chatNamespace, characterNamespace, storedSession] = await Promise.all([
+      this.readNamespace('compat:global'),
+      this.readNamespace(`compat:chat:${chatId}`),
+      this.readNamespace(`compat:character:${character.id}`),
+      this.readNamespace(`compat:session:${chatId}:${character.id}`),
+    ]);
+
+    let sessionState = isRecord(storedSession.stat_data)
+      ? { ...(storedSession.stat_data as JsonRecord) }
+      : {};
+    let eraData = storedSession.eraData;
+
+    for (const message of messages) {
+      const blocks = [...message.content.matchAll(VARIABLE_BLOCK_RE)];
+      for (const block of blocks) {
+        const type = block[1]?.toLowerCase();
+        const parsed = parseStructuredValue(block[2] ?? '');
+
+        if (type === 'variableinsert' || type === 'variableedit') {
+          if (isRecord(parsed)) {
+            sessionState = deepMerge(sessionState, parsed);
+          }
+          continue;
+        }
+
+        if (type === 'variabledelete') {
+          const targets = Array.isArray(parsed)
+            ? parsed.filter((value): value is string => typeof value === 'string')
+            : typeof parsed === 'string'
+              ? [parsed]
+              : [];
+          for (const target of targets) {
+            deleteByPath(sessionState, target);
+          }
+          continue;
+        }
+
+        if (type === 'era_data') {
+          eraData = parsed;
+        }
+      }
+    }
+
+    const messageCompat = extractMessageCompat(messages);
+    const nextSession = {
+      ...storedSession,
+      stat_data: sessionState,
+      eraData,
+      messageCompat,
+    };
+    await this.settingsService.set(`compat:session:${chatId}:${character.id}`, nextSession);
+
+    return {
+      manifest,
+      adapter,
+      namespaces: {
+        global: globalNamespace,
+        chat: chatNamespace,
+        character: characterNamespace,
+        session: nextSession,
+      },
+      sessionState,
+      eraData,
+      messageCompat,
+    };
+  }
+
+  async renderCharacter(
+    character: CharacterRow,
+    context: CompatPromptContext,
+  ): Promise<CharacterRow> {
+    if (!context.manifest?.promptCompat || !context.adapter) {
+      return character;
+    }
+
+    return {
+      ...character,
+      description: await this.renderContent(character.description, context),
+      personality: await this.renderContent(character.personality, context),
+      scenario: await this.renderContent(character.scenario, context),
+      system_prompt: await this.renderContent(character.system_prompt, context),
+      mes_example: await this.renderContent(character.mes_example, context),
+      post_history_instructions: await this.renderContent(
+        character.post_history_instructions,
+        context,
+      ),
+    };
+  }
+
+  async renderEntries(
+    entries: ActivatedEntry[],
+    context: CompatPromptContext,
+  ): Promise<ActivatedEntry[]> {
+    if (!context.manifest?.promptCompat || !context.adapter) return entries;
+
+    return Promise.all(
+      entries.map(async (entry) => ({
+        ...entry,
+        content: await this.renderContent(entry.content, context),
+      })),
+    );
+  }
+
+  async renderContent(content: string, context: CompatPromptContext): Promise<string> {
+    if (!content || !context.manifest?.promptCompat || !context.adapter) {
+      return content;
+    }
+
+    let output = content;
+
+    if (context.adapter === 'era') {
+      output = output.replace(
+        /\{\{ERA:\$ALLDATA\}\}/g,
+        JSON.stringify(context.sessionState, null, 2),
+      );
+    }
+
+    if (context.adapter === 'era' && /<%[\s\S]*?%>/.test(output)) {
+      return this.renderEraTemplate(output, context);
+    }
+
+    return output;
+  }
+
+  private async readNamespace(key: string): Promise<JsonRecord> {
+    const value = await this.settingsService.get(key);
+    return isRecord(value) ? value : {};
+  }
+
+  private async renderEraTemplate(content: string, context: CompatPromptContext): Promise<string> {
+    const templateRoot: JsonRecord = {
+      stat_data: context.sessionState,
+      ...context.sessionState,
+      __eraData: context.eraData,
+      __messageCompat: context.messageCompat,
+      globalVars: context.namespaces.global,
+      chatVars: context.namespaces.chat,
+      characterVars: context.namespaces.character,
+    };
+
+    const body: string[] = [
+      'let __out = "";',
+      'const print = (...args) => { __out += args.join(""); };',
+    ];
+    const matcher = /<%([=_-]?)([\s\S]*?)%>/g;
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = matcher.exec(content)) !== null) {
+      const [raw, marker, code] = match;
+      const text = content.slice(lastIndex, match.index);
+      if (text) {
+        body.push(`__out += ${JSON.stringify(text)};`);
+      }
+
+      if (marker === '=' || marker === '-') {
+        body.push(`__out += __stringify(await (${code.trim()}));`);
+      } else {
+        body.push(code.trim());
+      }
+
+      lastIndex = match.index + raw.length;
+    }
+
+    const tail = content.slice(lastIndex);
+    if (tail) {
+      body.push(`__out += ${JSON.stringify(tail)};`);
+    }
+    body.push('return __out;');
+
+    try {
+      const fn = new AsyncFunction(
+        '__helpers',
+        `
+          const __stringify = (value) => {
+            if (value == null) return "";
+            if (typeof value === "string") return value;
+            return JSON.stringify(value);
+          };
+          const {
+            getvar,
+            getVar,
+            setvar,
+            setVar,
+            addvar,
+            getMessageVar,
+            setMessageVar
+          } = __helpers;
+          with (__helpers) {
+            ${body.join('\n')}
+          }
+        `,
+      );
+
+      const result = await fn({
+        ...templateRoot,
+        getvar: (path: string, options?: { defaults?: unknown }) =>
+          getByPath(templateRoot, path) ?? options?.defaults,
+        getVar: (path: string, options?: { defaults?: unknown }) =>
+          getByPath(templateRoot, path) ?? options?.defaults,
+        setvar: (path: string, value: unknown) => setByPath(templateRoot, path, value),
+        setVar: (path: string, value: unknown) => setByPath(templateRoot, path, value),
+        addvar: (path: string, delta: number) => {
+          const current = Number(getByPath(templateRoot, path) ?? 0);
+          setByPath(templateRoot, path, current + delta);
+        },
+        getMessageVar: (path: string, options?: { defaults?: unknown }) =>
+          getByPath(context.messageCompat, path) ?? options?.defaults,
+        setMessageVar: (path: string, value: unknown) =>
+          setByPath(context.messageCompat, path, value),
+      });
+
+      return typeof result === 'string' ? result : JSON.stringify(result);
+    } catch {
+      return content;
+    }
+  }
+}


### PR DESCRIPTION
## 目的
在服务端增加 compat prompt runtime，把 compat 所需的上下文拼装、运行时语义和生成控制沉到后端，作为前端 sandbox/chat 路由层的上游能力。

## 变更内容
- 新增 `compat-prompt-runtime.service`
- 在 chat generation controller 中接入 compat prompt runtime
- 调整 chat module 依赖关系，注册新的运行时服务
- 补充 compat prompt runtime 的服务端测试

## 接口与兼容性
- 不修改已有前端 RPC 协议
- 这层主要是服务端生成链路增强
- 为后续 compat 聊天面板和 bridge runtime 提供服务端支持

## 验证
- compat prompt runtime 相关测试通过
- chat generation 相关测试覆盖保持存在
