### PR TITLE
feat(client): 通过 sandbox panel 路由 compat 聊天

### DIFF
--- a/client/compat-sandbox.html
+++ b/client/compat-sandbox.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Compat Sandbox</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/compat-sandbox-main.tsx"></script>
+  </body>
+</html>

--- a/client/components/chat/chat-panel-router.tsx
+++ b/client/components/chat/chat-panel-router.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { NativeChatPanel } from "./native-chat-panel";
+import { CompatSandboxPanel } from "./compat-sandbox-panel";
+import { useRuntimeMode } from "@/hooks/use-runtime-mode";
+
+export function ChatPanelRouter() {
+  const { runtimeMode } = useRuntimeMode();
+
+  if (runtimeMode === "compat-sandbox") {
+    return <CompatSandboxPanel />;
+  }
+
+  return <NativeChatPanel />;
+}

--- a/client/components/chat/compat-sandbox-panel.tsx
+++ b/client/components/chat/compat-sandbox-panel.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useChatStore } from "@/stores/chat-store";
+import { useCharacterStore } from "@/stores/character-store";
+import { useConnectionStore } from "@/stores/connection-store";
+import { usePromptManagerStore } from "@/stores/prompt-manager-store";
+import { useQuickReplyStore } from "@/stores/quick-reply-store";
+import { useVariableStore } from "@/stores/variable-store";
+import { useWorldInfoStore } from "@/stores/world-info-store";
+import { useRegexStore } from "@/stores/regex-store";
+import { useSidebar } from "@/components/ui/sidebar";
+import { ChatInput } from "./chat-input";
+import { ChatWelcomeScreen } from "./chat-welcome-screen";
+import { QuickReplyBar } from "./quick-reply-bar";
+import { useTranslation } from "@/lib/i18n";
+import { useGenerationConfig } from "@/hooks/use-generation-config";
+import { useChatActions } from "@/hooks/use-chat-actions";
+import type {
+  CompatSandboxSnapshot,
+  HostToSandboxMessage,
+  SandboxToHostMessage,
+} from "@/lib/compat-sandbox/protocol";
+
+export function CompatSandboxPanel() {
+  const { t } = useTranslation();
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const portRef = useRef<MessagePort | null>(null);
+
+  const {
+    messages,
+    isGenerating,
+    generationType,
+    streamingContent,
+    streamingReasoning,
+    streamingStructured,
+    currentChatId,
+    sendMessage,
+    stopGeneration,
+    generateSwipe,
+    continueMessage,
+    impersonate,
+    swipe,
+    deleteMessage,
+    refreshCurrentChat,
+    selectChat,
+    createChat,
+    deleteChat,
+  } = useChatStore(
+    useShallow((s) => ({
+      messages: s.messages,
+      isGenerating: s.isGenerating,
+      generationType: s.generationType,
+      streamingContent: s.streamingContent,
+      streamingReasoning: s.streamingReasoning,
+      streamingStructured: s.streamingStructured,
+      currentChatId: s.currentChatId,
+      sendMessage: s.sendMessage,
+      stopGeneration: s.stopGeneration,
+      generateSwipe: s.generateSwipe,
+      continueMessage: s.continueMessage,
+      impersonate: s.impersonate,
+      swipe: s.swipe,
+      deleteMessage: s.deleteMessage,
+      refreshCurrentChat: s.refreshCurrentChat,
+      selectChat: s.selectChat,
+      createChat: s.createChat,
+      deleteChat: s.deleteChat,
+    })),
+  );
+  const { selectedId, characters } = useCharacterStore(
+    useShallow((s) => ({
+      selectedId: s.selectedId,
+      characters: s.characters,
+    })),
+  );
+  const connection = useConnectionStore(
+    useShallow((s) => ({
+      provider: s.provider,
+      model: s.model,
+      temperature: s.temperature,
+      maxTokens: s.maxTokens,
+      topP: s.topP,
+      topK: s.topK,
+      frequencyPenalty: s.frequencyPenalty,
+      presencePenalty: s.presencePenalty,
+      reverseProxy: s.reverseProxy,
+      maxContext: s.maxContext,
+      openUiEnabled: s.openUiEnabled,
+      customApiFormat: s.customApiFormat,
+    })),
+  );
+  const promptComponents = usePromptManagerStore((s) => s.components);
+  const quickRepliesLoaded = useQuickReplyStore((s) => s.loaded);
+  const loadQuickReplies = useQuickReplyStore((s) => s.loadSets);
+  const loadGlobalVariables = useVariableStore((s) => s.loadGlobalVariables);
+  const loadChatVariables = useVariableStore((s) => s.loadChatVariables);
+  const globalVariables = useVariableStore((s) => s.globalVariables);
+  const chatVariables = useVariableStore((s) => s.chatVariables);
+  const activeBookIds = useWorldInfoStore((s) => s.activeBookIds);
+  const globalScripts = useRegexStore((s) => s.globalScripts);
+  const loadedGlobalScripts = useRegexStore((s) => s.loadedGlobalScripts);
+  const loadingGlobalScripts = useRegexStore((s) => s.loading);
+  const fetchGlobalScripts = useRegexStore((s) => s.fetchGlobalScripts);
+  const { toggleSidebar } = useSidebar();
+
+  const selectedChar = characters.find((c) => c.id === selectedId);
+  const { generationConfig } = useGenerationConfig({
+    connection,
+    promptComponents,
+    activeBookIds,
+    selectedChar,
+  });
+  const { handleSend, runSlashCommand } = useChatActions({
+    currentChatId,
+    selectedId,
+    generationConfig,
+    sendMessage,
+    continueMessage,
+    impersonate,
+    stopGeneration,
+    swipe,
+    deleteMessage,
+    generateSwipe,
+    refreshCurrentChat,
+    selectChat,
+    createChat,
+    deleteChat,
+    toggleSidebar,
+    t,
+  });
+
+  useEffect(() => {
+    void loadGlobalVariables();
+  }, [loadGlobalVariables]);
+
+  useEffect(() => {
+    if (currentChatId) {
+      void loadChatVariables(currentChatId);
+    }
+  }, [currentChatId, loadChatVariables]);
+
+  useEffect(() => {
+    if (!quickRepliesLoaded) {
+      void loadQuickReplies();
+    }
+  }, [loadQuickReplies, quickRepliesLoaded]);
+
+  useEffect(() => {
+    if (!loadedGlobalScripts && !loadingGlobalScripts) {
+      void fetchGlobalScripts();
+    }
+  }, [fetchGlobalScripts, loadedGlobalScripts, loadingGlobalScripts]);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe?.contentWindow) return;
+
+    const channel = new MessageChannel();
+    portRef.current?.close();
+    portRef.current = channel.port1;
+
+    channel.port1.onmessage = async (event: MessageEvent<SandboxToHostMessage>) => {
+      const data = event.data;
+      if (!data || data.type !== "rpc:call") return;
+
+      if (data.method === "runSlashCommand") {
+        try {
+          await runSlashCommand(data.params.command);
+          channel.port1.postMessage({
+            type: "rpc:result",
+            id: data.id,
+            result: true,
+          } satisfies SandboxToHostMessage);
+        } catch (error) {
+          channel.port1.postMessage({
+            type: "rpc:result",
+            id: data.id,
+            error: error instanceof Error ? error.message : String(error),
+          } satisfies SandboxToHostMessage);
+        }
+      }
+    };
+
+    iframe.contentWindow.postMessage({ type: "compat:port-transfer" }, "*", [channel.port2]);
+    return () => {
+      channel.port1.close();
+      portRef.current = null;
+    };
+  }, [runSlashCommand]);
+
+  const snapshot = useMemo<CompatSandboxSnapshot | null>(() => {
+    if (!currentChatId || !selectedChar) return null;
+
+    return {
+      chatId: currentChatId,
+      character: selectedChar,
+      messages,
+      globalScripts,
+      globalVariables,
+      chatVariables,
+      openUiEnabled: connection.openUiEnabled,
+      isGenerating,
+      generationType,
+      streamingContent,
+      streamingReasoning,
+      streamingStructured,
+    };
+  }, [
+    chatVariables,
+    connection.openUiEnabled,
+    currentChatId,
+    generationType,
+    globalScripts,
+    globalVariables,
+    isGenerating,
+    messages,
+    selectedChar,
+    streamingContent,
+    streamingReasoning,
+    streamingStructured,
+  ]);
+
+  useEffect(() => {
+    if (!snapshot || !portRef.current) return;
+
+    portRef.current.postMessage({
+      type: "session:update",
+      payload: snapshot,
+    } satisfies HostToSandboxMessage);
+  }, [snapshot]);
+
+  if (!selectedId || !currentChatId || !selectedChar) {
+    return <ChatWelcomeScreen />;
+  }
+
+  const hasAssistantMessage = messages.some((message) => message.role === "assistant");
+
+  return (
+    <main className="flex min-h-0 flex-1 flex-col">
+      <div className="flex h-10 shrink-0 items-center border-b border-border px-4">
+        <span className="text-sm font-medium">{selectedChar.name ?? t("chat.defaultTitle")}</span>
+      </div>
+
+      <div className="min-h-0 flex-1 bg-background">
+        <iframe
+          ref={iframeRef}
+          title="Compat Sandbox"
+          sandbox="allow-scripts allow-forms allow-modals allow-popups"
+          className="h-full w-full border-0"
+          src="/compat-sandbox.html"
+        />
+      </div>
+
+      <QuickReplyBar
+        onExecute={(script) => {
+          void runSlashCommand(script);
+        }}
+      />
+
+      <ChatInput
+        onSend={handleSend}
+        onSlashCommand={runSlashCommand}
+        onStop={stopGeneration}
+        onContinue={() => void continueMessage(generationConfig)}
+        onImpersonate={() => void impersonate(generationConfig)}
+        canContinue={hasAssistantMessage}
+        isGenerating={isGenerating}
+        disabled={false}
+      />
+    </main>
+  );
+}

--- a/client/components/chat/native-chat-panel.tsx
+++ b/client/components/chat/native-chat-panel.tsx
@@ -1,0 +1,1 @@
+export { ChatPanel as NativeChatPanel } from "./chat-panel";

--- a/client/hooks/use-runtime-mode.ts
+++ b/client/hooks/use-runtime-mode.ts
@@ -1,0 +1,24 @@
+import { useMemo } from "react";
+import { useCharacterStore } from "@/stores/character-store";
+import type { RuntimeAdapter, RuntimeManifest, RuntimeMode } from "@/lib/compat/runtime-manifest";
+
+export function useRuntimeMode(): {
+  runtimeMode: RuntimeMode;
+  runtimeManifest: RuntimeManifest | null;
+  runtimeAdapter: RuntimeAdapter | null;
+} {
+  const selectedId = useCharacterStore((s) => s.selectedId);
+  const characters = useCharacterStore((s) => s.characters);
+
+  return useMemo(() => {
+    const character = characters.find((item) => item.id === selectedId) ?? null;
+    const runtimeManifest = (character?.extensions?.runtimeManifest ??
+      null) as RuntimeManifest | null;
+
+    return {
+      runtimeMode: runtimeManifest?.runtimeMode ?? "native",
+      runtimeManifest,
+      runtimeAdapter: runtimeManifest?.adapter ?? null,
+    };
+  }, [characters, selectedId]);
+}

--- a/client/lib/compat-sandbox/protocol.ts
+++ b/client/lib/compat-sandbox/protocol.ts
@@ -1,0 +1,39 @@
+import type { Character } from "@/lib/api/character";
+import type { Message } from "@/lib/api/chat";
+import type { RegexScriptData } from "@/lib/compat/regex-engine";
+import type { GenerationType } from "@/lib/api/types";
+import type { PartialStructuredResponse } from "@/lib/openui/structured-types";
+
+export interface CompatSandboxSnapshot {
+  chatId: number;
+  character: Character;
+  messages: Message[];
+  globalScripts: RegexScriptData[];
+  globalVariables: Record<string, string>;
+  chatVariables: Record<string, string>;
+  openUiEnabled: boolean;
+  isGenerating: boolean;
+  generationType: GenerationType | null;
+  streamingContent: string;
+  streamingReasoning: string;
+  streamingStructured: PartialStructuredResponse | null;
+}
+
+export type HostToSandboxMessage = {
+  type: "session:update";
+  payload: CompatSandboxSnapshot;
+};
+
+export type SandboxToHostMessage =
+  | {
+      type: "rpc:call";
+      id: string;
+      method: "runSlashCommand";
+      params: { command: string };
+    }
+  | {
+      type: "rpc:result";
+      id: string;
+      result?: unknown;
+      error?: string;
+    };

--- a/client/src/__tests__/app-shell.test.tsx
+++ b/client/src/__tests__/app-shell.test.tsx
@@ -28,8 +28,8 @@ const personaState = {
   ],
 };
 
-vi.mock("@/components/chat/chat-panel", () => ({
-  ChatPanel: () => <div>chat-panel</div>,
+vi.mock("@/components/chat/chat-panel-router", () => ({
+  ChatPanelRouter: () => <div>chat-panel</div>,
 }));
 
 vi.mock("@/components/persona/persona-editor", () => ({

--- a/client/src/app-shell.tsx
+++ b/client/src/app-shell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ChatPanel } from "@/components/chat/chat-panel";
+import { ChatPanelRouter } from "@/components/chat/chat-panel-router";
 import { PersonaEditor } from "@/components/persona/persona-editor";
 import { PersonaSelector } from "@/components/persona/persona-selector";
 import { SettingsPanel } from "@/components/settings/settings-panel";
@@ -80,7 +80,7 @@ export function AppShell() {
               />
             </div>
           )}
-          <ChatPanel />
+          <ChatPanelRouter />
         </SidebarInset>
 
         <SettingsPanel />

--- a/client/src/compat-sandbox-app.tsx
+++ b/client/src/compat-sandbox-app.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { MessageBubble } from "@/components/chat/message-bubble";
+import { useCharacterStore } from "@/stores/character-store";
+import { useChatStore } from "@/stores/chat-store";
+import { useRegexStore } from "@/stores/regex-store";
+import { useVariableStore } from "@/stores/variable-store";
+import type { Message } from "@/lib/api/chat";
+import type {
+  CompatSandboxSnapshot,
+  HostToSandboxMessage,
+  SandboxToHostMessage,
+} from "@/lib/compat-sandbox/protocol";
+
+function useCompatSandboxBridge() {
+  const portRef = useRef<MessagePort | null>(null);
+  const pendingRef = useRef(
+    new Map<
+      string,
+      {
+        resolve: (value: unknown) => void;
+        reject: (reason?: unknown) => void;
+      }
+    >(),
+  );
+  const [snapshot, setSnapshot] = useState<CompatSandboxSnapshot | null>(null);
+
+  useEffect(() => {
+    const handleWindowMessage = (event: MessageEvent) => {
+      if (event.data?.type !== "compat:port-transfer" || !event.ports?.[0]) return;
+
+      const port = event.ports[0];
+      portRef.current = port;
+      port.onmessage = (portEvent: MessageEvent<HostToSandboxMessage | SandboxToHostMessage>) => {
+        const data = portEvent.data;
+        if (!data) return;
+
+        if (data.type === "session:update") {
+          setSnapshot(data.payload);
+          return;
+        }
+
+        if (data.type === "rpc:result") {
+          const pending = pendingRef.current.get(data.id);
+          if (!pending) return;
+          pendingRef.current.delete(data.id);
+          if (data.error) {
+            pending.reject(new Error(data.error));
+          } else {
+            pending.resolve(data.result);
+          }
+        }
+      };
+      port.start();
+    };
+
+    window.addEventListener("message", handleWindowMessage);
+    return () => {
+      window.removeEventListener("message", handleWindowMessage);
+      portRef.current?.close();
+      portRef.current = null;
+    };
+  }, []);
+
+  const runSlashCommand = async (command: string) => {
+    if (!portRef.current) return;
+
+    const id = `sandbox-rpc-${crypto.randomUUID()}`;
+    const result = new Promise<unknown>((resolve, reject) => {
+      pendingRef.current.set(id, { resolve, reject });
+    });
+
+    portRef.current.postMessage({
+      type: "rpc:call",
+      id,
+      method: "runSlashCommand",
+      params: { command },
+    } satisfies SandboxToHostMessage);
+
+    await result;
+  };
+
+  return { snapshot, runSlashCommand };
+}
+
+export function CompatSandboxApp() {
+  const { snapshot, runSlashCommand } = useCompatSandboxBridge();
+
+  useEffect(() => {
+    if (!snapshot) return;
+
+    useCharacterStore.setState({
+      selectedId: snapshot.character.id,
+      characters: [snapshot.character],
+    });
+    useChatStore.setState({
+      currentChatId: snapshot.chatId,
+      messages: snapshot.messages,
+      isGenerating: snapshot.isGenerating,
+      generationType: snapshot.generationType,
+      streamingContent: snapshot.streamingContent,
+      streamingReasoning: snapshot.streamingReasoning,
+      streamingStructured: snapshot.streamingStructured,
+      error: null,
+    });
+    useRegexStore.setState({
+      globalScripts: snapshot.globalScripts,
+      loadedGlobalScripts: true,
+      loading: false,
+    });
+    useVariableStore.setState({
+      globalVariables: snapshot.globalVariables,
+      chatVariables: snapshot.chatVariables,
+      currentChatId: snapshot.chatId,
+    });
+  }, [snapshot]);
+
+  const latestAssistantMessageId = useMemo(() => {
+    if (!snapshot) return null;
+    for (let i = snapshot.messages.length - 1; i >= 0; i -= 1) {
+      if (snapshot.messages[i].role === "assistant") return snapshot.messages[i].id;
+    }
+    return null;
+  }, [snapshot]);
+
+  if (!snapshot) {
+    return <div className="p-4 text-sm text-muted-foreground">Loading compat runtime…</div>;
+  }
+
+  const isSwipeGenerating =
+    snapshot.isGenerating &&
+    (snapshot.generationType === "swipe" || snapshot.generationType === "regenerate");
+
+  return (
+    <main className="min-h-screen bg-background px-4 py-6 text-foreground">
+      <div className="mx-auto flex max-w-3xl flex-col gap-6">
+        {snapshot.messages.map((message: Message) => {
+          const isLastAssistant =
+            message.role === "assistant" && message.id === latestAssistantMessageId;
+          const showSwipeStreaming = isLastAssistant && isSwipeGenerating;
+
+          return (
+            <MessageBubble
+              key={message.id}
+              messageId={message.id}
+              role={message.role}
+              name={
+                message.name || (message.role === "assistant" ? snapshot.character.name : undefined)
+              }
+              content={
+                showSwipeStreaming
+                  ? snapshot.streamingContent
+                  : message.structuredContent
+                    ? ""
+                    : message.content
+              }
+              reasoning={
+                showSwipeStreaming ? snapshot.streamingReasoning || undefined : message.reasoning
+              }
+              isStreaming={showSwipeStreaming}
+              swipeId={message.swipeId}
+              swipes={message.swipes}
+              openUiEnabled={snapshot.openUiEnabled}
+              structuredContent={
+                showSwipeStreaming ? snapshot.streamingStructured : message.structuredContent
+              }
+              onStructuredAction={() => undefined}
+              onStructuredCommandAction={() => undefined}
+              onWidgetSlashCommand={runSlashCommand}
+            />
+          );
+        })}
+
+        {snapshot.isGenerating &&
+          !isSwipeGenerating &&
+          (snapshot.streamingContent ||
+            snapshot.streamingReasoning ||
+            snapshot.streamingStructured) && (
+            <MessageBubble
+              role="assistant"
+              name={snapshot.character.name}
+              content={snapshot.streamingContent}
+              reasoning={snapshot.streamingReasoning}
+              isStreaming
+              openUiEnabled={snapshot.openUiEnabled}
+              structuredContent={snapshot.streamingStructured}
+              onStructuredAction={() => undefined}
+              onStructuredCommandAction={() => undefined}
+              onWidgetSlashCommand={runSlashCommand}
+            />
+          )}
+      </div>
+    </main>
+  );
+}

--- a/client/src/compat-sandbox-main.tsx
+++ b/client/src/compat-sandbox-main.tsx
@@ -1,0 +1,19 @@
+import "@fontsource-variable/geist";
+import "@fontsource-variable/geist-mono";
+import "@fontsource-variable/noto-sans";
+import "./globals.css";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { CompatSandboxApp } from "./compat-sandbox-app";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Failed to find compat sandbox root");
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <CompatSandboxApp />
+  </StrictMode>,
+);

--- a/client/stores/chat-store.ts
+++ b/client/stores/chat-store.ts
@@ -60,8 +60,8 @@ const streamingBuffer: StreamingSnapshot = emptyStreamingSnapshot();
 
 // Chunk throttle — keeps at most one pending snapshot and drains every CHUNK_INTERVAL_MS
 let pendingChunk: Partial<StreamingSnapshot> | null = null;
-let drainHandle: ReturnType<typeof setTimeout> | null = null;
-const CHUNK_INTERVAL_MS = 25;
+let drainHandle: number | ReturnType<typeof setTimeout> | null = null;
+let usesAnimationFrame = false;
 
 function clearStreamingBuffer() {
   streamingBuffer.streamingContent = "";
@@ -72,8 +72,13 @@ function clearStreamingBuffer() {
 function clearChunkQueue() {
   pendingChunk = null;
   if (drainHandle !== null) {
-    clearTimeout(drainHandle);
+    if (usesAnimationFrame && typeof cancelAnimationFrame === "function") {
+      cancelAnimationFrame(drainHandle as number);
+    } else {
+      clearTimeout(drainHandle as ReturnType<typeof setTimeout>);
+    }
     drainHandle = null;
+    usesAnimationFrame = false;
   }
 }
 
@@ -105,14 +110,25 @@ function enqueueChunk(data: Partial<StreamingSnapshot>) {
     pendingChunk = { ...data };
   }
   if (drainHandle === null) {
-    drainHandle = setTimeout(drainChunkQueue, CHUNK_INTERVAL_MS);
+    if (typeof requestAnimationFrame === "function") {
+      usesAnimationFrame = true;
+      drainHandle = requestAnimationFrame(() => drainChunkQueue());
+    } else {
+      usesAnimationFrame = false;
+      drainHandle = setTimeout(drainChunkQueue, 25);
+    }
   }
 }
 
 function flushAllChunks() {
   if (drainHandle !== null) {
-    clearTimeout(drainHandle);
+    if (usesAnimationFrame && typeof cancelAnimationFrame === "function") {
+      cancelAnimationFrame(drainHandle as number);
+    } else {
+      clearTimeout(drainHandle as ReturnType<typeof setTimeout>);
+    }
     drainHandle = null;
+    usesAnimationFrame = false;
   }
   if (pendingChunk) {
     applyChunkToBuffer(pendingChunk);

--- a/server/src/modules/character/character.controller.ts
+++ b/server/src/modules/character/character.controller.ts
@@ -150,11 +150,46 @@ export class CharacterController {
   private buildRuntimeManifestCard(character: Awaited<ReturnType<CharacterService['findOne']>>) {
     if (!character) return null;
 
-    const extensions = this.safeJsonParse<Record<string, unknown>>(character.extensions, {});
-    const characterBook = this.safeJsonParse<Record<string, unknown> | null>(
+    const rawExtensions = this.safeJsonParse<Record<string, unknown>>(character.extensions, {});
+    const rawDepthPrompt =
+      rawExtensions.depth_prompt &&
+      typeof rawExtensions.depth_prompt === 'object' &&
+      rawExtensions.depth_prompt !== null
+        ? (rawExtensions.depth_prompt as Record<string, unknown>)
+        : null;
+    const rawDepthPromptRole = rawDepthPrompt?.role;
+    const depthPromptRole: 'system' | 'user' | 'assistant' =
+      rawDepthPromptRole === 'user' || rawDepthPromptRole === 'assistant'
+        ? rawDepthPromptRole
+        : 'system';
+    const extensions = {
+      talkativeness:
+        typeof rawExtensions.talkativeness === 'number' ? rawExtensions.talkativeness : 0.5,
+      fav: Boolean(rawExtensions.fav),
+      world: typeof rawExtensions.world === 'string' ? rawExtensions.world : '',
+      depth_prompt: rawDepthPrompt
+        ? {
+            prompt: typeof rawDepthPrompt.prompt === 'string' ? rawDepthPrompt.prompt : '',
+            depth: typeof rawDepthPrompt.depth === 'number' ? rawDepthPrompt.depth : 4,
+            role: depthPromptRole,
+          }
+        : {
+            prompt: '',
+            depth: 4,
+            role: 'system' as const,
+          },
+      ...rawExtensions,
+    };
+    const rawCharacterBook = this.safeJsonParse<Record<string, unknown> | null>(
       character.character_book,
       null,
     );
+    const characterBook = rawCharacterBook
+      ? {
+          ...rawCharacterBook,
+          entries: Array.isArray(rawCharacterBook.entries) ? rawCharacterBook.entries : [],
+        }
+      : null;
 
     return {
       spec: 'chara_card_v2' as const,

--- a/server/src/modules/chat/compat-prompt-runtime.service.ts
+++ b/server/src/modules/chat/compat-prompt-runtime.service.ts
@@ -130,7 +130,7 @@ function extractManifest(character: CharacterRow): RuntimeManifest | null {
   try {
     const extensions = JSON.parse(character.extensions || '{}') as JsonRecord;
     return isRecord(extensions.runtimeManifest)
-      ? (extensions.runtimeManifest as RuntimeManifest)
+      ? (extensions.runtimeManifest as unknown as RuntimeManifest)
       : null;
   } catch {
     return null;


### PR DESCRIPTION
## 目的
把 compat 聊天流量从原生聊天面板切到 sandbox panel，为后续 bridge/runtime 和 iframe API 扩展建立稳定承载层。

## 变更内容
- 新增 compat sandbox 面板与独立入口
- 聊天面板路由支持根据运行时模式切到 compat 面板
- 增加 compat sandbox 页面与主入口挂载
- 补齐 runtime mode 相关前端状态接线
- 调整少量角色/聊天侧数据流，确保 compat 面板可获取所需上下文

## 接口与兼容性
- 对用户可见变化是 compat 聊天走 sandbox 面板渲染
- 不改已有聊天协议
- 作为后续 bridge runtime 的直接前置层

## 验证
- app shell / 路由 / compat 面板相关测试包含在后续整栈验证中
