### PR TITLE
feat(client): 增加 compat sandbox bridge 运行时

### DIFF
--- a/client/components/chat/compat-sandbox-panel.tsx
+++ b/client/components/chat/compat-sandbox-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useChatStore } from "@/stores/chat-store";
 import { useCharacterStore } from "@/stores/character-store";
@@ -17,16 +17,21 @@ import { QuickReplyBar } from "./quick-reply-bar";
 import { useTranslation } from "@/lib/i18n";
 import { useGenerationConfig } from "@/hooks/use-generation-config";
 import { useChatActions } from "@/hooks/use-chat-actions";
-import type {
-  CompatSandboxSnapshot,
-  HostToSandboxMessage,
-  SandboxToHostMessage,
-} from "@/lib/compat-sandbox/protocol";
+import { BridgeManager, type CompatSandboxSnapshot } from "@/lib/compat-sandbox/bridge-manager";
 
 export function CompatSandboxPanel() {
   const { t } = useTranslation();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const portRef = useRef<MessagePort | null>(null);
+  const managerRef = useRef<BridgeManager | null>(null);
+  const rpcContextRef = useRef({
+    currentChatId: null as number | null,
+    selectedCharId: null as number | null,
+    selectedCharName: "",
+    messageCount: 0,
+    globalVariables: {} as Record<string, string>,
+    chatVariables: {} as Record<string, string>,
+  });
+  const [iframeLoaded, setIframeLoaded] = useState(false);
 
   const {
     messages,
@@ -105,7 +110,7 @@ export function CompatSandboxPanel() {
   const fetchGlobalScripts = useRegexStore((s) => s.fetchGlobalScripts);
   const { toggleSidebar } = useSidebar();
 
-  const selectedChar = characters.find((c) => c.id === selectedId);
+  const selectedChar = characters.find((character) => character.id === selectedId);
   const { generationConfig } = useGenerationConfig({
     connection,
     promptComponents,
@@ -154,44 +159,80 @@ export function CompatSandboxPanel() {
   }, [fetchGlobalScripts, loadedGlobalScripts, loadingGlobalScripts]);
 
   useEffect(() => {
-    const iframe = iframeRef.current;
-    if (!iframe?.contentWindow) return;
+    rpcContextRef.current = {
+      currentChatId,
+      selectedCharId: selectedChar?.id ?? null,
+      selectedCharName: selectedChar?.name ?? "",
+      messageCount: messages.length,
+      globalVariables,
+      chatVariables,
+    };
+  }, [
+    chatVariables,
+    currentChatId,
+    globalVariables,
+    messages.length,
+    selectedChar?.id,
+    selectedChar?.name,
+  ]);
 
-    const channel = new MessageChannel();
-    portRef.current?.close();
-    portRef.current = channel.port1;
+  useEffect(() => {
+    if (!iframeLoaded || !iframeRef.current) return;
 
-    channel.port1.onmessage = async (event: MessageEvent<SandboxToHostMessage>) => {
-      const data = event.data;
-      if (!data || data.type !== "rpc:call") return;
-
-      if (data.method === "runSlashCommand") {
-        try {
-          await runSlashCommand(data.params.command);
-          channel.port1.postMessage({
-            type: "rpc:result",
-            id: data.id,
-            result: true,
-          } satisfies SandboxToHostMessage);
-        } catch (error) {
-          channel.port1.postMessage({
-            type: "rpc:result",
-            id: data.id,
-            error: error instanceof Error ? error.message : String(error),
-          } satisfies SandboxToHostMessage);
+    managerRef.current?.dispose();
+    managerRef.current = new BridgeManager(iframeRef.current, async (rpc) => {
+      try {
+        switch (rpc.method) {
+          case "runSlashCommand":
+            await runSlashCommand(String(rpc.params?.command ?? ""));
+            managerRef.current?.reply(rpc.id, true);
+            return;
+          case "getContext":
+            managerRef.current?.reply(rpc.id, {
+              chatId: rpcContextRef.current.currentChatId,
+              characterId: rpcContextRef.current.selectedCharId,
+              characterName: rpcContextRef.current.selectedCharName,
+              messageCount: rpcContextRef.current.messageCount,
+            });
+            return;
+          case "getVariables":
+            managerRef.current?.reply(rpc.id, {
+              global: rpcContextRef.current.globalVariables,
+              chat: rpcContextRef.current.chatVariables,
+            });
+            return;
+          case "requestWriteDone":
+            managerRef.current?.reply(rpc.id, {
+              global: rpcContextRef.current.globalVariables,
+              chat: rpcContextRef.current.chatVariables,
+            });
+            return;
         }
+      } catch (error) {
+        managerRef.current?.reply(
+          rpc.id,
+          undefined,
+          error instanceof Error ? error.message : String(error),
+        );
       }
-    };
+    });
+    managerRef.current.connect();
 
-    iframe.contentWindow.postMessage({ type: "compat:port-transfer" }, "*", [channel.port2]);
     return () => {
-      channel.port1.close();
-      portRef.current = null;
+      managerRef.current?.dispose();
+      managerRef.current = null;
     };
-  }, [runSlashCommand]);
+  }, [iframeLoaded, runSlashCommand]);
 
   const snapshot = useMemo<CompatSandboxSnapshot | null>(() => {
     if (!currentChatId || !selectedChar) return null;
+
+    const latestAssistantMessageId = [...messages]
+      .reverse()
+      .find((message) => message.role === "assistant")?.id;
+    const isSwipeStreaming =
+      isGenerating && (generationType === "swipe" || generationType === "regenerate");
+    const streamingMessageId = isSwipeStreaming ? (latestAssistantMessageId ?? -1) : -1;
 
     return {
       chatId: currentChatId,
@@ -201,8 +242,7 @@ export function CompatSandboxPanel() {
       globalVariables,
       chatVariables,
       openUiEnabled: connection.openUiEnabled,
-      isGenerating,
-      generationType,
+      streamingMessageId,
       streamingContent,
       streamingReasoning,
       streamingStructured,
@@ -223,12 +263,8 @@ export function CompatSandboxPanel() {
   ]);
 
   useEffect(() => {
-    if (!snapshot || !portRef.current) return;
-
-    portRef.current.postMessage({
-      type: "session:update",
-      payload: snapshot,
-    } satisfies HostToSandboxMessage);
+    if (!snapshot || !managerRef.current) return;
+    managerRef.current.sync(snapshot);
   }, [snapshot]);
 
   if (!selectedId || !currentChatId || !selectedChar) {
@@ -250,6 +286,7 @@ export function CompatSandboxPanel() {
           sandbox="allow-scripts allow-forms allow-modals allow-popups"
           className="h-full w-full border-0"
           src="/compat-sandbox.html"
+          onLoad={() => setIframeLoaded(true)}
         />
       </div>
 

--- a/client/lib/compat-sandbox/bridge-client.ts
+++ b/client/lib/compat-sandbox/bridge-client.ts
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState } from "react";
+import type { CompatSandboxSession, HostToSandboxMessage, SandboxToHostMessage } from "./protocol";
+
+export interface CompatSandboxBridgeState {
+  session: CompatSandboxSession | null;
+  streamingMessageId: number;
+  streamingContent: string;
+  streamingReasoning: string;
+  streamingStructured: HostToSandboxMessage extends infer T
+    ? T extends { type: "message:append"; payload: { delta: infer D } }
+      ? D extends { structured?: infer S }
+        ? S
+        : null
+      : null
+    : null;
+}
+
+export function useBridgeClient() {
+  const portRef = useRef<MessagePort | null>(null);
+  const pendingRef = useRef(
+    new Map<
+      string,
+      {
+        resolve: (value: unknown) => void;
+        reject: (reason?: unknown) => void;
+      }
+    >(),
+  );
+  const [state, setState] = useState<CompatSandboxBridgeState>({
+    session: null,
+    streamingMessageId: -1,
+    streamingContent: "",
+    streamingReasoning: "",
+    streamingStructured: null,
+  });
+
+  useEffect(() => {
+    const handleWindowMessage = (event: MessageEvent) => {
+      if (event.data?.type !== "compat:port-transfer" || !event.ports?.[0]) return;
+
+      const port = event.ports[0];
+      portRef.current = port;
+      port.onmessage = (portEvent: MessageEvent<HostToSandboxMessage | SandboxToHostMessage>) => {
+        const data = portEvent.data;
+        if (!data) return;
+
+        switch (data.type) {
+          case "session:init":
+            setState({
+              session: data.payload,
+              streamingMessageId: -1,
+              streamingContent: "",
+              streamingReasoning: "",
+              streamingStructured: null,
+            });
+            break;
+          case "message:upsert":
+            setState((current) => {
+              if (!current.session) return current;
+              const nextMessages = current.session.messages.some(
+                (message) => message.id === data.payload.message.id,
+              )
+                ? current.session.messages.map((message) =>
+                    message.id === data.payload.message.id ? data.payload.message : message,
+                  )
+                : [...current.session.messages, data.payload.message];
+              const shouldClearStreaming =
+                current.streamingMessageId === -1 &&
+                data.payload.message.role === "assistant" &&
+                data.payload.message.content.length > 0;
+              return {
+                ...current,
+                session: {
+                  ...current.session,
+                  messages: nextMessages,
+                },
+                streamingMessageId: shouldClearStreaming ? -1 : current.streamingMessageId,
+                streamingContent: shouldClearStreaming ? "" : current.streamingContent,
+                streamingReasoning: shouldClearStreaming ? "" : current.streamingReasoning,
+                streamingStructured: shouldClearStreaming ? null : current.streamingStructured,
+              };
+            });
+            break;
+          case "message:append":
+            setState((current) => ({
+              ...current,
+              streamingMessageId: data.payload.messageId,
+              streamingContent:
+                data.payload.delta.content !== undefined &&
+                current.streamingMessageId === data.payload.messageId &&
+                current.streamingContent &&
+                data.payload.delta.content &&
+                !data.payload.delta.content.startsWith(current.streamingContent)
+                  ? `${current.streamingContent}${data.payload.delta.content}`
+                  : (data.payload.delta.content ?? current.streamingContent),
+              streamingReasoning:
+                data.payload.delta.reasoning !== undefined &&
+                current.streamingMessageId === data.payload.messageId &&
+                current.streamingReasoning &&
+                data.payload.delta.reasoning &&
+                !data.payload.delta.reasoning.startsWith(current.streamingReasoning)
+                  ? `${current.streamingReasoning}${data.payload.delta.reasoning}`
+                  : (data.payload.delta.reasoning ?? current.streamingReasoning),
+              streamingStructured:
+                data.payload.delta.structured !== undefined
+                  ? data.payload.delta.structured
+                  : current.streamingStructured,
+            }));
+            break;
+          case "message:finalize":
+            setState((current) =>
+              current.streamingMessageId !== data.payload.messageId
+                ? current
+                : {
+                    ...current,
+                    streamingMessageId: -1,
+                    streamingContent: "",
+                    streamingReasoning: "",
+                    streamingStructured: null,
+                  },
+            );
+            break;
+          case "vars:patch":
+            setState((current) =>
+              current.session
+                ? {
+                    ...current,
+                    session: {
+                      ...current.session,
+                      ...data.payload,
+                      character: data.payload.character ?? current.session.character,
+                      globalScripts: data.payload.globalScripts ?? current.session.globalScripts,
+                      globalVariables:
+                        data.payload.globalVariables ?? current.session.globalVariables,
+                      chatVariables: data.payload.chatVariables ?? current.session.chatVariables,
+                      openUiEnabled: data.payload.openUiEnabled ?? current.session.openUiEnabled,
+                    },
+                  }
+                : current,
+            );
+            break;
+          case "rpc:result": {
+            const pending = pendingRef.current.get(data.id);
+            if (!pending) return;
+            pendingRef.current.delete(data.id);
+            if (data.error) {
+              pending.reject(new Error(data.error));
+            } else {
+              pending.resolve(data.result);
+            }
+            break;
+          }
+        }
+      };
+      port.start();
+    };
+
+    window.addEventListener("message", handleWindowMessage);
+    return () => {
+      window.removeEventListener("message", handleWindowMessage);
+      portRef.current?.close();
+      portRef.current = null;
+    };
+  }, []);
+
+  const call = async (
+    method: Extract<SandboxToHostMessage, { type: "rpc:call" }>["method"],
+    params?: Record<string, unknown>,
+  ) => {
+    if (!portRef.current) return undefined;
+
+    const id = `sandbox-rpc-${crypto.randomUUID()}`;
+    const result = new Promise<unknown>((resolve, reject) => {
+      pendingRef.current.set(id, { resolve, reject });
+    });
+
+    portRef.current.postMessage({
+      type: "rpc:call",
+      id,
+      method,
+      params,
+    } satisfies SandboxToHostMessage);
+
+    return result;
+  };
+
+  return { state, call };
+}

--- a/client/lib/compat-sandbox/bridge-manager.ts
+++ b/client/lib/compat-sandbox/bridge-manager.ts
@@ -1,0 +1,196 @@
+import type { Character } from "@/lib/api/character";
+import type { Message } from "@/lib/api/chat";
+import type {
+  CompatSandboxSession,
+  CompatStreamingDelta,
+  HostToSandboxMessage,
+  SandboxToHostMessage,
+} from "./protocol";
+
+export interface CompatSandboxSnapshot extends CompatSandboxSession {
+  streamingMessageId: number;
+  streamingContent: string;
+  streamingReasoning: string;
+  streamingStructured: CompatStreamingDelta["structured"];
+}
+
+function sameMessage(a: Message, b: Message): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function diffStreaming(
+  previous: CompatSandboxSnapshot | null,
+  next: CompatSandboxSnapshot,
+): CompatStreamingDelta | null {
+  const prevContent = previous?.streamingContent ?? "";
+  const prevReasoning = previous?.streamingReasoning ?? "";
+  const prevStructured = previous?.streamingStructured ?? null;
+
+  if (
+    next.streamingContent === prevContent &&
+    next.streamingReasoning === prevReasoning &&
+    next.streamingStructured === prevStructured
+  ) {
+    return null;
+  }
+
+  return {
+    content:
+      next.streamingContent.startsWith(prevContent) &&
+      next.streamingContent.length >= prevContent.length
+        ? next.streamingContent.slice(prevContent.length)
+        : next.streamingContent,
+    reasoning:
+      next.streamingReasoning.startsWith(prevReasoning) &&
+      next.streamingReasoning.length >= prevReasoning.length
+        ? next.streamingReasoning.slice(prevReasoning.length)
+        : next.streamingReasoning,
+    structured: next.streamingStructured,
+  };
+}
+
+export class BridgeManager {
+  private port: MessagePort | null = null;
+  private snapshot: CompatSandboxSnapshot | null = null;
+
+  constructor(
+    private readonly iframe: HTMLIFrameElement,
+    private readonly onRpcCall: (
+      payload: Extract<SandboxToHostMessage, { type: "rpc:call" }>,
+    ) => Promise<void>,
+  ) {}
+
+  connect() {
+    const contentWindow = this.iframe.contentWindow;
+    if (!contentWindow) return;
+
+    const channel = new MessageChannel();
+    this.port?.close();
+    this.port = channel.port1;
+    this.port.onmessage = (event: MessageEvent<SandboxToHostMessage>) => {
+      const data = event.data;
+      if (!data || data.type !== "rpc:call") return;
+      void this.onRpcCall(data);
+    };
+    this.port.start();
+
+    contentWindow.postMessage({ type: "compat:port-transfer" }, "*", [channel.port2]);
+  }
+
+  dispose() {
+    this.port?.close();
+    this.port = null;
+    this.snapshot = null;
+  }
+
+  reply(id: string, result?: unknown, error?: string) {
+    if (!this.port) return;
+    this.port.postMessage({
+      type: "rpc:result",
+      id,
+      result,
+      error,
+    } satisfies SandboxToHostMessage);
+  }
+
+  sync(next: CompatSandboxSnapshot) {
+    if (!this.port) return;
+
+    if (!this.snapshot) {
+      this.port.postMessage({
+        type: "session:init",
+        payload: {
+          chatId: next.chatId,
+          character: next.character,
+          messages: next.messages,
+          globalScripts: next.globalScripts,
+          globalVariables: next.globalVariables,
+          chatVariables: next.chatVariables,
+          openUiEnabled: next.openUiEnabled,
+        },
+      } satisfies HostToSandboxMessage);
+      this.snapshot = next;
+      return;
+    }
+
+    if (this.snapshot.character.id !== next.character.id) {
+      this.snapshot = null;
+      this.sync(next);
+      return;
+    }
+
+    if (
+      JSON.stringify(this.snapshot.globalScripts) !== JSON.stringify(next.globalScripts) ||
+      JSON.stringify(this.snapshot.globalVariables) !== JSON.stringify(next.globalVariables) ||
+      JSON.stringify(this.snapshot.chatVariables) !== JSON.stringify(next.chatVariables) ||
+      this.snapshot.openUiEnabled !== next.openUiEnabled ||
+      JSON.stringify(this.snapshot.character) !== JSON.stringify(next.character)
+    ) {
+      this.port.postMessage({
+        type: "vars:patch",
+        payload: {
+          character: next.character as Character,
+          globalScripts: next.globalScripts,
+          globalVariables: next.globalVariables,
+          chatVariables: next.chatVariables,
+          openUiEnabled: next.openUiEnabled,
+        },
+      } satisfies HostToSandboxMessage);
+    }
+
+    const previousMessages = new Map(
+      this.snapshot.messages.map((message) => [message.id, message]),
+    );
+    let requiresFullReset = next.messages.length < this.snapshot.messages.length;
+
+    if (!requiresFullReset) {
+      for (const message of next.messages) {
+        const previousMessage = previousMessages.get(message.id);
+        if (!previousMessage || !sameMessage(previousMessage, message)) {
+          this.port.postMessage({
+            type: "message:upsert",
+            payload: { message },
+          } satisfies HostToSandboxMessage);
+        }
+      }
+    }
+
+    if (requiresFullReset) {
+      this.snapshot = null;
+      this.sync(next);
+      return;
+    }
+
+    const delta = diffStreaming(this.snapshot, next);
+    if (
+      delta &&
+      (delta.content || delta.reasoning || delta.structured !== undefined) &&
+      (next.streamingContent || next.streamingReasoning || next.streamingStructured)
+    ) {
+      this.port.postMessage({
+        type: "message:append",
+        payload: {
+          messageId: next.streamingMessageId,
+          delta,
+        },
+      } satisfies HostToSandboxMessage);
+    }
+
+    if (
+      this.snapshot.streamingContent ||
+      this.snapshot.streamingReasoning ||
+      this.snapshot.streamingStructured
+    ) {
+      if (!next.streamingContent && !next.streamingReasoning && !next.streamingStructured) {
+        this.port.postMessage({
+          type: "message:finalize",
+          payload: {
+            messageId: this.snapshot.streamingMessageId,
+          },
+        } satisfies HostToSandboxMessage);
+      }
+    }
+
+    this.snapshot = next;
+  }
+}

--- a/client/lib/compat-sandbox/protocol.ts
+++ b/client/lib/compat-sandbox/protocol.ts
@@ -1,10 +1,9 @@
 import type { Character } from "@/lib/api/character";
 import type { Message } from "@/lib/api/chat";
 import type { RegexScriptData } from "@/lib/compat/regex-engine";
-import type { GenerationType } from "@/lib/api/types";
 import type { PartialStructuredResponse } from "@/lib/openui/structured-types";
 
-export interface CompatSandboxSnapshot {
+export interface CompatSandboxSession {
   chatId: number;
   character: Character;
   messages: Message[];
@@ -12,24 +11,56 @@ export interface CompatSandboxSnapshot {
   globalVariables: Record<string, string>;
   chatVariables: Record<string, string>;
   openUiEnabled: boolean;
-  isGenerating: boolean;
-  generationType: GenerationType | null;
-  streamingContent: string;
-  streamingReasoning: string;
-  streamingStructured: PartialStructuredResponse | null;
 }
 
-export type HostToSandboxMessage = {
-  type: "session:update";
-  payload: CompatSandboxSnapshot;
-};
+export interface CompatStreamingDelta {
+  content?: string;
+  reasoning?: string;
+  structured?: PartialStructuredResponse | null;
+}
+
+export type HostToSandboxMessage =
+  | {
+      type: "session:init";
+      payload: CompatSandboxSession;
+    }
+  | {
+      type: "message:upsert";
+      payload: { message: Message };
+    }
+  | {
+      type: "message:append";
+      payload: {
+        messageId: number;
+        delta: CompatStreamingDelta;
+      };
+    }
+  | {
+      type: "message:finalize";
+      payload: { messageId: number };
+    }
+  | {
+      type: "vars:patch";
+      payload: Partial<
+        Pick<
+          CompatSandboxSession,
+          "character" | "globalScripts" | "globalVariables" | "chatVariables" | "openUiEnabled"
+        >
+      >;
+    };
+
+export type SandboxRpcMethod =
+  | "runSlashCommand"
+  | "getContext"
+  | "getVariables"
+  | "requestWriteDone";
 
 export type SandboxToHostMessage =
   | {
       type: "rpc:call";
       id: string;
-      method: "runSlashCommand";
-      params: { command: string };
+      method: SandboxRpcMethod;
+      params?: Record<string, unknown>;
     }
   | {
       type: "rpc:result";

--- a/client/src/compat-sandbox-app.tsx
+++ b/client/src/compat-sandbox-app.tsx
@@ -1,142 +1,65 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo } from "react";
+import type { Message } from "@/lib/api/chat";
 import { MessageBubble } from "@/components/chat/message-bubble";
+import { useBridgeClient } from "@/lib/compat-sandbox/bridge-client";
 import { useCharacterStore } from "@/stores/character-store";
 import { useChatStore } from "@/stores/chat-store";
 import { useRegexStore } from "@/stores/regex-store";
 import { useVariableStore } from "@/stores/variable-store";
-import type { Message } from "@/lib/api/chat";
-import type {
-  CompatSandboxSnapshot,
-  HostToSandboxMessage,
-  SandboxToHostMessage,
-} from "@/lib/compat-sandbox/protocol";
-
-function useCompatSandboxBridge() {
-  const portRef = useRef<MessagePort | null>(null);
-  const pendingRef = useRef(
-    new Map<
-      string,
-      {
-        resolve: (value: unknown) => void;
-        reject: (reason?: unknown) => void;
-      }
-    >(),
-  );
-  const [snapshot, setSnapshot] = useState<CompatSandboxSnapshot | null>(null);
-
-  useEffect(() => {
-    const handleWindowMessage = (event: MessageEvent) => {
-      if (event.data?.type !== "compat:port-transfer" || !event.ports?.[0]) return;
-
-      const port = event.ports[0];
-      portRef.current = port;
-      port.onmessage = (portEvent: MessageEvent<HostToSandboxMessage | SandboxToHostMessage>) => {
-        const data = portEvent.data;
-        if (!data) return;
-
-        if (data.type === "session:update") {
-          setSnapshot(data.payload);
-          return;
-        }
-
-        if (data.type === "rpc:result") {
-          const pending = pendingRef.current.get(data.id);
-          if (!pending) return;
-          pendingRef.current.delete(data.id);
-          if (data.error) {
-            pending.reject(new Error(data.error));
-          } else {
-            pending.resolve(data.result);
-          }
-        }
-      };
-      port.start();
-    };
-
-    window.addEventListener("message", handleWindowMessage);
-    return () => {
-      window.removeEventListener("message", handleWindowMessage);
-      portRef.current?.close();
-      portRef.current = null;
-    };
-  }, []);
-
-  const runSlashCommand = async (command: string) => {
-    if (!portRef.current) return;
-
-    const id = `sandbox-rpc-${crypto.randomUUID()}`;
-    const result = new Promise<unknown>((resolve, reject) => {
-      pendingRef.current.set(id, { resolve, reject });
-    });
-
-    portRef.current.postMessage({
-      type: "rpc:call",
-      id,
-      method: "runSlashCommand",
-      params: { command },
-    } satisfies SandboxToHostMessage);
-
-    await result;
-  };
-
-  return { snapshot, runSlashCommand };
-}
 
 export function CompatSandboxApp() {
-  const { snapshot, runSlashCommand } = useCompatSandboxBridge();
+  const { state, call } = useBridgeClient();
 
   useEffect(() => {
-    if (!snapshot) return;
+    if (!state.session) return;
 
     useCharacterStore.setState({
-      selectedId: snapshot.character.id,
-      characters: [snapshot.character],
+      selectedId: state.session.character.id,
+      characters: [state.session.character],
     });
     useChatStore.setState({
-      currentChatId: snapshot.chatId,
-      messages: snapshot.messages,
-      isGenerating: snapshot.isGenerating,
-      generationType: snapshot.generationType,
-      streamingContent: snapshot.streamingContent,
-      streamingReasoning: snapshot.streamingReasoning,
-      streamingStructured: snapshot.streamingStructured,
+      currentChatId: state.session.chatId,
+      messages: state.session.messages,
       error: null,
     });
     useRegexStore.setState({
-      globalScripts: snapshot.globalScripts,
+      globalScripts: state.session.globalScripts,
       loadedGlobalScripts: true,
       loading: false,
     });
     useVariableStore.setState({
-      globalVariables: snapshot.globalVariables,
-      chatVariables: snapshot.chatVariables,
-      currentChatId: snapshot.chatId,
+      globalVariables: state.session.globalVariables,
+      chatVariables: state.session.chatVariables,
+      currentChatId: state.session.chatId,
     });
-  }, [snapshot]);
+  }, [state.session]);
 
   const latestAssistantMessageId = useMemo(() => {
-    if (!snapshot) return null;
-    for (let i = snapshot.messages.length - 1; i >= 0; i -= 1) {
-      if (snapshot.messages[i].role === "assistant") return snapshot.messages[i].id;
+    if (!state.session) return null;
+    for (let index = state.session.messages.length - 1; index >= 0; index -= 1) {
+      if (state.session.messages[index].role === "assistant") {
+        return state.session.messages[index].id;
+      }
     }
     return null;
-  }, [snapshot]);
+  }, [state.session]);
 
-  if (!snapshot) {
+  if (!state.session) {
     return <div className="p-4 text-sm text-muted-foreground">Loading compat runtime…</div>;
   }
 
-  const isSwipeGenerating =
-    snapshot.isGenerating &&
-    (snapshot.generationType === "swipe" || snapshot.generationType === "regenerate");
+  const session = state.session;
+
+  const runSlashCommand = async (command: string) => {
+    await call("runSlashCommand", { command });
+  };
 
   return (
     <main className="min-h-screen bg-background px-4 py-6 text-foreground">
       <div className="mx-auto flex max-w-3xl flex-col gap-6">
-        {snapshot.messages.map((message: Message) => {
-          const isLastAssistant =
-            message.role === "assistant" && message.id === latestAssistantMessageId;
-          const showSwipeStreaming = isLastAssistant && isSwipeGenerating;
+        {state.session.messages.map((message: Message) => {
+          const showStreaming =
+            state.streamingMessageId === message.id && message.id === latestAssistantMessageId;
 
           return (
             <MessageBubble
@@ -144,24 +67,22 @@ export function CompatSandboxApp() {
               messageId={message.id}
               role={message.role}
               name={
-                message.name || (message.role === "assistant" ? snapshot.character.name : undefined)
+                message.name || (message.role === "assistant" ? session.character.name : undefined)
               }
               content={
-                showSwipeStreaming
-                  ? snapshot.streamingContent
+                showStreaming
+                  ? state.streamingContent
                   : message.structuredContent
                     ? ""
                     : message.content
               }
-              reasoning={
-                showSwipeStreaming ? snapshot.streamingReasoning || undefined : message.reasoning
-              }
-              isStreaming={showSwipeStreaming}
+              reasoning={showStreaming ? state.streamingReasoning || undefined : message.reasoning}
+              isStreaming={showStreaming}
               swipeId={message.swipeId}
               swipes={message.swipes}
-              openUiEnabled={snapshot.openUiEnabled}
+              openUiEnabled={session.openUiEnabled}
               structuredContent={
-                showSwipeStreaming ? snapshot.streamingStructured : message.structuredContent
+                showStreaming ? state.streamingStructured : message.structuredContent
               }
               onStructuredAction={() => undefined}
               onStructuredCommandAction={() => undefined}
@@ -170,19 +91,16 @@ export function CompatSandboxApp() {
           );
         })}
 
-        {snapshot.isGenerating &&
-          !isSwipeGenerating &&
-          (snapshot.streamingContent ||
-            snapshot.streamingReasoning ||
-            snapshot.streamingStructured) && (
+        {state.streamingMessageId === -1 &&
+          (state.streamingContent || state.streamingReasoning || state.streamingStructured) && (
             <MessageBubble
               role="assistant"
-              name={snapshot.character.name}
-              content={snapshot.streamingContent}
-              reasoning={snapshot.streamingReasoning}
+              name={state.session.character.name}
+              content={state.streamingContent}
+              reasoning={state.streamingReasoning}
               isStreaming
-              openUiEnabled={snapshot.openUiEnabled}
-              structuredContent={snapshot.streamingStructured}
+              openUiEnabled={session.openUiEnabled}
+              structuredContent={state.streamingStructured}
               onStructuredAction={() => undefined}
               onStructuredCommandAction={() => undefined}
               onWidgetSlashCommand={runSlashCommand}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
   plugins: [react()],
   build: {
     rolldownOptions: {
+      input: {
+        main: fileURLToPath(new URL("./index.html", import.meta.url)),
+        compatSandbox: fileURLToPath(new URL("./compat-sandbox.html", import.meta.url)),
+      },
       output: {
         manualChunks(id) {
           const isSettingsModule =


### PR DESCRIPTION
## 目的
为 compat sandbox 建立稳定的 host-iframe bridge runtime，把消息传递、连接管理和宿主侧抽象从面板中拆出来。

## 变更内容
- 新增 bridge client 与 bridge manager
- 把 compat sandbox panel 中的 bridge 逻辑抽离成独立运行时模块
- 调整协议文件与入口接线，减少面板组件的内联桥接逻辑
- 更新 Vite 配置以支持 compat sandbox 入口构建

## 接口与兼容性
- 不改变外部 RPC 协议语义
- 主要是宿主侧 bridge 实现抽象化
- 为后续 RPC registry 与 iframe API 扩展提供更清晰的承载边界

## 验证
- bridge runtime 已在后续 registry / generation 测试链路中被间接覆盖
