### PR TITLE
refactor(compat): 声明式注册内建 RPC 处理器

### DIFF
--- a/client/components/chat/compat-html-widget.tsx
+++ b/client/components/chat/compat-html-widget.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { chatApi } from "@/lib/api/chat";
-import { ST_COMPAT_VARS_KEY } from "@/lib/compat/js-runtime";
+import { dispatchRpc, type RpcContext } from "@/lib/compat-sandbox/rpc-registry";
+import { registerBuiltinHandlers } from "@/lib/compat-sandbox/rpc-handlers";
+import { injectBootstrap } from "@/lib/compat-sandbox/bootstrap-generator";
 import type { CompatBridgeData } from "@/lib/compat/widget-pipeline";
-import { useChatStore } from "@/stores/chat-store";
-import { useCharacterStore } from "@/stores/character-store";
-import { useVariableStore } from "@/stores/variable-store";
 
 interface CompatHtmlWidgetProps {
   messageId?: number;
@@ -16,214 +14,19 @@ interface CompatHtmlWidgetProps {
   onRunSlashCommand?: (command: string) => Promise<void> | void;
 }
 
-type WidgetHostRpcRequest = {
+interface WidgetIncomingMessage {
   __arcWidget: true;
   widgetId: string;
-  type: "rpc";
-  id: string;
-  method: string;
+  type: "rpc" | "emit" | "ready" | "resize";
+  // rpc fields
+  id?: string;
+  method?: string;
   params?: Record<string, unknown>;
-};
-
-type WidgetHostEventRequest = {
-  __arcWidget: true;
-  widgetId: string;
-  type: "emit";
-  event: string;
+  // emit fields
+  event?: string;
   detail?: unknown;
-};
-
-type WidgetHostReadyRequest = {
-  __arcWidget: true;
-  widgetId: string;
-  type: "ready";
-};
-
-type WidgetHostResizeRequest = {
-  __arcWidget: true;
-  widgetId: string;
-  type: "resize";
+  // resize fields
   height?: number;
-};
-
-type WidgetIncomingMessage =
-  | WidgetHostRpcRequest
-  | WidgetHostEventRequest
-  | WidgetHostReadyRequest
-  | WidgetHostResizeRequest;
-
-function getCompatVarRow(messageId: number | undefined, swipeId: number): Record<string, unknown> {
-  if (!messageId) return {};
-
-  const message = useChatStore.getState().messages.find((item) => item.id === messageId);
-  const raw = message?.extra?.[ST_COMPAT_VARS_KEY];
-  if (!Array.isArray(raw)) return {};
-
-  const row = raw[swipeId];
-  return row && typeof row === "object" ? { ...(row as Record<string, unknown>) } : {};
-}
-
-function buildBridgeBootstrap(widgetId: string): string {
-  return `
-<script>
-(function () {
-  var __widgetId = ${JSON.stringify(widgetId)};
-  var __listeners = new Map();
-  var __pending = new Map();
-  var __counter = 0;
-
-  function __notifyResize() {
-    var height = 240;
-    try {
-      var body = document.body;
-      var docEl = document.documentElement;
-      height = Math.max(
-        body ? body.scrollHeight : 0,
-        body ? body.offsetHeight : 0,
-        docEl ? docEl.scrollHeight : 0,
-        docEl ? docEl.offsetHeight : 0,
-        240
-      );
-    } catch (error) {}
-
-    parent.postMessage(
-      { __arcWidget: true, widgetId: __widgetId, type: "resize", height: height },
-      "*"
-    );
-  }
-
-  function __dispatch(eventName, detail) {
-    var handlers = __listeners.get(eventName);
-    if (!handlers) return;
-    handlers.forEach(function (handler) {
-      try {
-        handler(detail);
-      } catch (error) {
-        console.error("[compat-widget] listener error", error);
-      }
-    });
-  }
-
-  function __rpc(method, params) {
-    return new Promise(function (resolve, reject) {
-      var id = "__arc_widget_rpc_" + (++__counter);
-      __pending.set(id, { resolve: resolve, reject: reject });
-      parent.postMessage(
-        { __arcWidget: true, widgetId: __widgetId, type: "rpc", id: id, method: method, params: params || {} },
-        "*"
-      );
-    });
-  }
-
-  async function __loadIntoTarget(target, url) {
-    var response = await fetch(url);
-    var html = await response.text();
-    var parser = new DOMParser();
-    var parsed = parser.parseFromString(html, "text/html");
-
-    Array.from(parsed.head.querySelectorAll("style, link[rel='stylesheet']")).forEach(function (node) {
-      document.head.appendChild(node.cloneNode(true));
-    });
-
-    if (target) {
-      target.innerHTML = parsed.body ? parsed.body.innerHTML : html;
-    }
-
-    var scriptNodes = Array.from(parsed.querySelectorAll("script"));
-    for (var i = 0; i < scriptNodes.length; i += 1) {
-      var source = scriptNodes[i];
-      var script = document.createElement("script");
-      Array.from(source.attributes).forEach(function (attr) {
-        script.setAttribute(attr.name, attr.value);
-      });
-      script.textContent = source.textContent;
-      document.body.appendChild(script);
-    }
-
-    __notifyResize();
-  }
-
-  window.eventOn = function (eventName, handler) {
-    if (!__listeners.has(eventName)) {
-      __listeners.set(eventName, new Set());
-    }
-    __listeners.get(eventName).add(handler);
-    return function () {
-      var handlers = __listeners.get(eventName);
-      if (handlers) handlers.delete(handler);
-    };
-  };
-
-  window.eventEmit = function (eventName, detail) {
-    parent.postMessage(
-      { __arcWidget: true, widgetId: __widgetId, type: "emit", event: eventName, detail: detail },
-      "*"
-    );
-  };
-
-  window.ArcTavern = {
-    getContext: function () { return __rpc("getContext"); },
-    getVariable: function (name, scope) { return __rpc("getVariable", { name: name, scope: scope || "auto" }); },
-    setVariable: function (name, value, scope) { return __rpc("setVariable", { name: name, value: value, scope: scope || "compat" }); },
-    runSlashCommand: function (command) { return __rpc("runSlashCommand", { command: command }); },
-    requestWriteDone: function () { return __rpc("requestWriteDone"); },
-    requestUiRefresh: function () { __notifyResize(); }
-  };
-
-  window.$ = function (selector) {
-    var target = typeof selector === "string" ? document.querySelector(selector) : selector;
-    return {
-      load: function (url) {
-        return __loadIntoTarget(target, url);
-      }
-    };
-  };
-
-  window.addEventListener("message", function (event) {
-    if (event.source !== parent) return;
-    var data = event.data;
-    if (!data || data.__arcWidget !== true || data.widgetId !== __widgetId) return;
-
-    if (data.type === "dispatch") {
-      __dispatch(data.event, data.detail);
-      return;
-    }
-
-    if (data.type === "rpcResult") {
-      var pending = __pending.get(data.id);
-      if (!pending) return;
-      __pending.delete(data.id);
-      if (data.error) {
-        pending.reject(new Error(data.error));
-      } else {
-        pending.resolve(data.result);
-      }
-    }
-  });
-
-  window.addEventListener("load", __notifyResize);
-  document.addEventListener("DOMContentLoaded", __notifyResize);
-  if (typeof ResizeObserver !== "undefined") {
-    new ResizeObserver(__notifyResize).observe(document.documentElement);
-  }
-
-  parent.postMessage({ __arcWidget: true, widgetId: __widgetId, type: "ready" }, "*");
-})();
-</script>`;
-}
-
-function injectBootstrap(html: string, widgetId: string): string {
-  const bootstrap = buildBridgeBootstrap(widgetId);
-
-  if (/<\/head>/i.test(html)) {
-    return html.replace(/<\/head>/i, `${bootstrap}</head>`);
-  }
-
-  if (/<body[^>]*>/i.test(html)) {
-    return html.replace(/<body([^>]*)>/i, `<body$1>${bootstrap}`);
-  }
-
-  return `<!DOCTYPE html><html><head>${bootstrap}</head><body>${html}</body></html>`;
 }
 
 export function CompatHtmlWidget({
@@ -240,33 +43,7 @@ export function CompatHtmlWidget({
   const srcDoc = useMemo(() => injectBootstrap(html, widgetIdRef.current), [html]);
 
   useEffect(() => {
-    async function updateCompatVariable(name: string, value: unknown) {
-      if (!messageId) return;
-
-      const message = useChatStore.getState().messages.find((item) => item.id === messageId);
-      if (!message) return;
-
-      const extra = { ...message.extra };
-      const raw = extra[ST_COMPAT_VARS_KEY];
-      const rows = Array.isArray(raw) ? [...raw] : [];
-      while (rows.length <= swipeId) {
-        rows.push({});
-      }
-
-      const row =
-        rows[swipeId] && typeof rows[swipeId] === "object"
-          ? { ...(rows[swipeId] as Record<string, unknown>) }
-          : {};
-
-      row[name] = value;
-      rows[swipeId] = row;
-      extra[ST_COMPAT_VARS_KEY] = rows;
-
-      const updated = await chatApi.updateMessage(messageId, { extra });
-      useChatStore.setState((state) => ({
-        messages: state.messages.map((item) => (item.id === messageId ? updated : item)),
-      }));
-    }
+    registerBuiltinHandlers();
 
     function postToWidget(message: Record<string, unknown>) {
       iframeRef.current?.contentWindow?.postMessage(
@@ -279,79 +56,14 @@ export function CompatHtmlWidget({
       );
     }
 
-    function buildContext() {
-      const variableStore = useVariableStore.getState();
-      const characterStore = useCharacterStore.getState();
-      const characterId = characterStore.selectedId;
-      const character = characterStore.characters.find((item) => item.id === characterId);
-      const messages = useChatStore
-        .getState()
-        .messages.map((item) => ({ id: item.id, role: item.role, content: item.content }));
-
+    function buildRpcContext(): RpcContext {
       return {
-        compatData,
-        globalVariables: variableStore.globalVariables,
-        chatVariables: variableStore.chatVariables,
-        compatVariables: getCompatVarRow(messageId, swipeId),
-        character: {
-          id: character?.id ?? null,
-          name: character?.name ?? "",
-          avatar: character?.avatar ?? "",
-        },
-        message: {
-          id: messageId ?? null,
-          swipeId,
-          extra:
-            useChatStore.getState().messages.find((item) => item.id === messageId)?.extra ?? {},
-        },
-        messages,
+        chatId: null,
+        characterId: null,
+        messageId,
+        swipeId,
+        extras: { compatData },
       };
-    }
-
-    async function handleRpc(method: string, params: Record<string, unknown> = {}) {
-      const variableStore = useVariableStore.getState();
-      const compatRow = getCompatVarRow(messageId, swipeId);
-      const name = typeof params.name === "string" ? params.name : "";
-      const scope = typeof params.scope === "string" ? params.scope : "auto";
-
-      switch (method) {
-        case "getContext":
-          return buildContext();
-        case "requestWriteDone":
-          return { statWithoutMeta: compatData.statWithoutMeta };
-        case "getVariable":
-          if (!name) return undefined;
-          if (scope === "compat") return compatRow[name];
-          if (scope === "chat") return variableStore.chatVariables[name];
-          if (scope === "global") return variableStore.globalVariables[name];
-          return (
-            compatRow[name] ??
-            variableStore.chatVariables[name] ??
-            variableStore.globalVariables[name]
-          );
-        case "setVariable": {
-          if (!name) return false;
-          const value = params.value;
-          if (scope === "global") {
-            variableStore.setGlobalVariable(name, String(value ?? ""));
-            return true;
-          }
-          if (scope === "chat") {
-            variableStore.setChatVariable(name, String(value ?? ""));
-            return true;
-          }
-          await updateCompatVariable(name, value);
-          return true;
-        }
-        case "runSlashCommand": {
-          const command = typeof params.command === "string" ? params.command : "";
-          if (!command || !onRunSlashCommand) return false;
-          await onRunSlashCommand(command);
-          return true;
-        }
-        default:
-          return undefined;
-      }
     }
 
     async function handleMessage(event: MessageEvent) {
@@ -366,11 +78,17 @@ export function CompatHtmlWidget({
       }
 
       if (data.type === "ready") {
-        postToWidget({
-          type: "dispatch",
-          event: "arctavern:context",
-          detail: buildContext(),
-        });
+        try {
+          const ctx = buildRpcContext();
+          const context = await dispatchRpc("getContext", {}, ctx);
+          postToWidget({
+            type: "dispatch",
+            event: "arctavern:context",
+            detail: context,
+          });
+        } catch {
+          /* ignore */
+        }
         return;
       }
 
@@ -382,11 +100,17 @@ export function CompatHtmlWidget({
             detail: { statWithoutMeta: compatData.statWithoutMeta },
           });
         } else if (data.event === "arctavern:requestContext") {
-          postToWidget({
-            type: "dispatch",
-            event: "arctavern:context",
-            detail: buildContext(),
-          });
+          try {
+            const ctx = buildRpcContext();
+            const context = await dispatchRpc("getContext", {}, ctx);
+            postToWidget({
+              type: "dispatch",
+              event: "arctavern:context",
+              detail: context,
+            });
+          } catch {
+            /* ignore */
+          }
         } else if (
           data.event === "slash:run" &&
           data.detail &&
@@ -400,14 +124,11 @@ export function CompatHtmlWidget({
         return;
       }
 
-      if (data.type === "rpc") {
+      if (data.type === "rpc" && data.id && data.method) {
+        const ctx = buildRpcContext();
         try {
-          const result = await handleRpc(data.method, data.params);
-          postToWidget({
-            type: "rpcResult",
-            id: data.id,
-            result,
-          });
+          const result = await dispatchRpc(data.method, data.params ?? {}, ctx);
+          postToWidget({ type: "rpcResult", id: data.id, result });
         } catch (error) {
           postToWidget({
             type: "rpcResult",

--- a/client/components/chat/compat-sandbox-panel.tsx
+++ b/client/components/chat/compat-sandbox-panel.tsx
@@ -18,6 +18,8 @@ import { useTranslation } from "@/lib/i18n";
 import { useGenerationConfig } from "@/hooks/use-generation-config";
 import { useChatActions } from "@/hooks/use-chat-actions";
 import { BridgeManager, type CompatSandboxSnapshot } from "@/lib/compat-sandbox/bridge-manager";
+import { dispatchRpc, type RpcContext } from "@/lib/compat-sandbox/rpc-registry";
+import { registerBuiltinHandlers } from "@/lib/compat-sandbox/rpc-handlers";
 
 export function CompatSandboxPanel() {
   const { t } = useTranslation();
@@ -179,35 +181,17 @@ export function CompatSandboxPanel() {
   useEffect(() => {
     if (!iframeLoaded || !iframeRef.current) return;
 
+    registerBuiltinHandlers();
     managerRef.current?.dispose();
     managerRef.current = new BridgeManager(iframeRef.current, async (rpc) => {
+      const ctx: RpcContext = {
+        chatId: rpcContextRef.current.currentChatId,
+        characterId: rpcContextRef.current.selectedCharId,
+        extras: {},
+      };
       try {
-        switch (rpc.method) {
-          case "runSlashCommand":
-            await runSlashCommand(String(rpc.params?.command ?? ""));
-            managerRef.current?.reply(rpc.id, true);
-            return;
-          case "getContext":
-            managerRef.current?.reply(rpc.id, {
-              chatId: rpcContextRef.current.currentChatId,
-              characterId: rpcContextRef.current.selectedCharId,
-              characterName: rpcContextRef.current.selectedCharName,
-              messageCount: rpcContextRef.current.messageCount,
-            });
-            return;
-          case "getVariables":
-            managerRef.current?.reply(rpc.id, {
-              global: rpcContextRef.current.globalVariables,
-              chat: rpcContextRef.current.chatVariables,
-            });
-            return;
-          case "requestWriteDone":
-            managerRef.current?.reply(rpc.id, {
-              global: rpcContextRef.current.globalVariables,
-              chat: rpcContextRef.current.chatVariables,
-            });
-            return;
-        }
+        const result = await dispatchRpc(rpc.method, rpc.params ?? {}, ctx);
+        managerRef.current?.reply(rpc.id, result);
       } catch (error) {
         managerRef.current?.reply(
           rpc.id,

--- a/client/lib/compat-sandbox/__tests__/rpc-registry.test.ts
+++ b/client/lib/compat-sandbox/__tests__/rpc-registry.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearRpcRegistryForTests,
+  registerRpcHandler,
+  registerRpcAlias,
+  getRpcHandler,
+  hasRpcHandler,
+  dispatchRpc,
+  listRpcMethods,
+  type RpcContext,
+} from "../rpc-registry";
+import {
+  builtinRpcHandlerEntries,
+  registerBuiltinHandlers,
+  resetBuiltinHandlersForTests,
+} from "../rpc-handlers";
+
+const stubCtx: RpcContext = {
+  chatId: 1,
+  characterId: 2,
+  extras: {},
+};
+
+describe("rpc-registry", () => {
+  beforeEach(() => {
+    clearRpcRegistryForTests();
+    resetBuiltinHandlersForTests();
+  });
+
+  it("registers and retrieves a handler", () => {
+    registerRpcHandler("test:echo", (params) => params.value);
+    expect(hasRpcHandler("test:echo")).toBe(true);
+    expect(getRpcHandler("test:echo")).toBeDefined();
+  });
+
+  it("dispatches to a registered handler", async () => {
+    registerRpcHandler("test:add", (params) => {
+      return (Number(params.a) || 0) + (Number(params.b) || 0);
+    });
+    const result = await dispatchRpc("test:add", { a: 3, b: 4 }, stubCtx);
+    expect(result).toBe(7);
+  });
+
+  it("throws for unknown method", async () => {
+    await expect(dispatchRpc("test:nonexistent", {}, stubCtx)).rejects.toThrow(
+      "Unknown RPC method: test:nonexistent",
+    );
+  });
+
+  it("registers aliases", async () => {
+    registerRpcHandler("test:original", () => "original");
+    registerRpcAlias("test:alias", "test:original");
+    const result = await dispatchRpc("test:alias", {}, stubCtx);
+    expect(result).toBe("original");
+  });
+
+  it("lists registered methods", () => {
+    registerRpcHandler("test:listed", () => null);
+    const methods = listRpcMethods();
+    expect(methods).toContain("test:listed");
+  });
+
+  it("passes context to handler", async () => {
+    registerRpcHandler("test:ctx", (_params, ctx) => ctx.chatId);
+    const result = await dispatchRpc("test:ctx", {}, { ...stubCtx, chatId: 42 });
+    expect(result).toBe(42);
+  });
+
+  it("registers builtin canonical methods exactly once", () => {
+    registerBuiltinHandlers();
+    registerBuiltinHandlers();
+
+    const methods = listRpcMethods();
+
+    for (const [method] of builtinRpcHandlerEntries) {
+      expect(methods).toContain(method);
+    }
+
+    expect(methods).toHaveLength(builtinRpcHandlerEntries.length);
+  });
+
+  it("dispatches builtins after registration", async () => {
+    registerBuiltinHandlers();
+
+    await expect(dispatchRpc("getContext", {}, stubCtx)).resolves.toEqual(
+      expect.objectContaining({
+        chatId: stubCtx.chatId,
+        characterId: stubCtx.characterId,
+      }),
+    );
+  });
+});

--- a/client/lib/compat-sandbox/bootstrap-generator.ts
+++ b/client/lib/compat-sandbox/bootstrap-generator.ts
@@ -1,0 +1,177 @@
+/**
+ * Generates the JavaScript bootstrap script injected into compat iframes.
+ *
+ * The bootstrap establishes:
+ *  - `window.ArcTavern` as a Proxy that auto-routes any method call to an RPC.
+ *  - `window.eventOn()` / `window.eventEmit()` for pub-sub.
+ *  - `window.$()` for dynamic HTML loading.
+ *  - Auto-resize via ResizeObserver.
+ *
+ * Using a Proxy means new RPC handlers registered on the host are automatically
+ * callable from iframes without changing this script.
+ */
+
+export function buildBridgeBootstrap(widgetId: string): string {
+  return `<script>
+(function () {
+  var __widgetId = ${JSON.stringify(widgetId)};
+  var __listeners = new Map();
+  var __pending = new Map();
+  var __counter = 0;
+
+  function __notifyResize() {
+    var height = 240;
+    try {
+      var body = document.body;
+      var docEl = document.documentElement;
+      height = Math.max(
+        body ? body.scrollHeight : 0,
+        body ? body.offsetHeight : 0,
+        docEl ? docEl.scrollHeight : 0,
+        docEl ? docEl.offsetHeight : 0,
+        240
+      );
+    } catch (error) {}
+
+    parent.postMessage(
+      { __arcWidget: true, widgetId: __widgetId, type: "resize", height: height },
+      "*"
+    );
+  }
+
+  function __dispatch(eventName, detail) {
+    var handlers = __listeners.get(eventName);
+    if (!handlers) return;
+    handlers.forEach(function (handler) {
+      try {
+        handler(detail);
+      } catch (error) {
+        console.error("[compat-widget] listener error", error);
+      }
+    });
+  }
+
+  function __rpc(method, params) {
+    return new Promise(function (resolve, reject) {
+      var id = "__arc_widget_rpc_" + (++__counter);
+      __pending.set(id, { resolve: resolve, reject: reject });
+      parent.postMessage(
+        { __arcWidget: true, widgetId: __widgetId, type: "rpc", id: id, method: method, params: params || {} },
+        "*"
+      );
+    });
+  }
+
+  async function __loadIntoTarget(target, url) {
+    var response = await fetch(url);
+    var html = await response.text();
+    var parser = new DOMParser();
+    var parsed = parser.parseFromString(html, "text/html");
+
+    Array.from(parsed.head.querySelectorAll("style, link[rel='stylesheet']")).forEach(function (node) {
+      document.head.appendChild(node.cloneNode(true));
+    });
+
+    if (target) {
+      target.innerHTML = parsed.body ? parsed.body.innerHTML : html;
+    }
+
+    var scriptNodes = Array.from(parsed.querySelectorAll("script"));
+    for (var i = 0; i < scriptNodes.length; i += 1) {
+      var source = scriptNodes[i];
+      var script = document.createElement("script");
+      Array.from(source.attributes).forEach(function (attr) {
+        script.setAttribute(attr.name, attr.value);
+      });
+      script.textContent = source.textContent;
+      document.body.appendChild(script);
+    }
+
+    __notifyResize();
+  }
+
+  window.eventOn = function (eventName, handler) {
+    if (!__listeners.has(eventName)) {
+      __listeners.set(eventName, new Set());
+    }
+    __listeners.get(eventName).add(handler);
+    return function () {
+      var handlers = __listeners.get(eventName);
+      if (handlers) handlers.delete(handler);
+    };
+  };
+
+  window.eventEmit = function (eventName, detail) {
+    parent.postMessage(
+      { __arcWidget: true, widgetId: __widgetId, type: "emit", event: eventName, detail: detail },
+      "*"
+    );
+  };
+
+  window.ArcTavern = new Proxy({
+    requestUiRefresh: function () { __notifyResize(); }
+  }, {
+    get: function (target, prop) {
+      if (typeof prop !== "string") return undefined;
+      if (prop in target) return target[prop];
+      return function (params) {
+        return __rpc(prop, typeof params === "object" && params !== null ? params : {});
+      };
+    }
+  });
+
+  window.$ = function (selector) {
+    var target = typeof selector === "string" ? document.querySelector(selector) : selector;
+    return {
+      load: function (url) {
+        return __loadIntoTarget(target, url);
+      }
+    };
+  };
+
+  window.addEventListener("message", function (event) {
+    if (event.source !== parent) return;
+    var data = event.data;
+    if (!data || data.__arcWidget !== true || data.widgetId !== __widgetId) return;
+
+    if (data.type === "dispatch") {
+      __dispatch(data.event, data.detail);
+      return;
+    }
+
+    if (data.type === "rpcResult") {
+      var pending = __pending.get(data.id);
+      if (!pending) return;
+      __pending.delete(data.id);
+      if (data.error) {
+        pending.reject(new Error(data.error));
+      } else {
+        pending.resolve(data.result);
+      }
+    }
+  });
+
+  window.addEventListener("load", __notifyResize);
+  document.addEventListener("DOMContentLoaded", __notifyResize);
+  if (typeof ResizeObserver !== "undefined") {
+    new ResizeObserver(__notifyResize).observe(document.documentElement);
+  }
+
+  parent.postMessage({ __arcWidget: true, widgetId: __widgetId, type: "ready" }, "*");
+})();
+</script>`;
+}
+
+export function injectBootstrap(html: string, widgetId: string): string {
+  const bootstrap = buildBridgeBootstrap(widgetId);
+
+  if (/<\/head>/i.test(html)) {
+    return html.replace(/<\/head>/i, `${bootstrap}</head>`);
+  }
+
+  if (/<body[^>]*>/i.test(html)) {
+    return html.replace(/<body([^>]*)>/i, `<body$1>${bootstrap}`);
+  }
+
+  return `<!DOCTYPE html><html><head>${bootstrap}</head><body>${html}</body></html>`;
+}

--- a/client/lib/compat-sandbox/protocol.ts
+++ b/client/lib/compat-sandbox/protocol.ts
@@ -49,17 +49,17 @@ export type HostToSandboxMessage =
       >;
     };
 
-export type SandboxRpcMethod =
-  | "runSlashCommand"
-  | "getContext"
-  | "getVariables"
-  | "requestWriteDone";
+/**
+ * RPC method name. Widened to `string` — the rpc-registry is the source of
+ * truth for which methods are available, not this type.
+ */
+export type SandboxRpcMethod = string;
 
 export type SandboxToHostMessage =
   | {
       type: "rpc:call";
       id: string;
-      method: SandboxRpcMethod;
+      method: string;
       params?: Record<string, unknown>;
     }
   | {

--- a/client/lib/compat-sandbox/rpc-handlers/commands.ts
+++ b/client/lib/compat-sandbox/rpc-handlers/commands.ts
@@ -1,0 +1,14 @@
+/**
+ * RPC handler: slash command execution.
+ */
+
+import { executeSlashCommand } from "@/lib/slash-commands/executor";
+import type { RpcHandler } from "../rpc-registry";
+
+export const runSlashCommand: RpcHandler = async (params, ctx) => {
+  const command = typeof params.command === "string" ? params.command : "";
+  if (!command || ctx.chatId == null) return false;
+
+  await executeSlashCommand(command, ctx.chatId);
+  return true;
+};

--- a/client/lib/compat-sandbox/rpc-handlers/context.ts
+++ b/client/lib/compat-sandbox/rpc-handlers/context.ts
@@ -1,0 +1,135 @@
+/**
+ * RPC handlers: context queries (getContext, getVariables, requestWriteDone).
+ */
+
+import { useChatStore } from "@/stores/chat-store";
+import { useCharacterStore } from "@/stores/character-store";
+import { useVariableStore } from "@/stores/variable-store";
+import { ST_COMPAT_VARS_KEY } from "@/lib/compat/js-runtime";
+import { type RpcHandler } from "../rpc-registry";
+
+function getCompatVarRow(messageId: number | undefined, swipeId: number): Record<string, unknown> {
+  if (!messageId) return {};
+
+  const message = useChatStore.getState().messages.find((item) => item.id === messageId);
+  const raw = message?.extra?.[ST_COMPAT_VARS_KEY];
+  if (!Array.isArray(raw)) return {};
+
+  const row = raw[swipeId];
+  return row && typeof row === "object" ? { ...(row as Record<string, unknown>) } : {};
+}
+
+export const getContext: RpcHandler = (_params, ctx) => {
+  const charStore = useCharacterStore.getState();
+  const chatStore = useChatStore.getState();
+  const variableStore = useVariableStore.getState();
+  const character = charStore.characters.find((c) => c.id === ctx.characterId);
+
+  if (ctx.messageId !== undefined) {
+    const messages = chatStore.messages.map((m) => ({
+      id: m.id,
+      role: m.role,
+      content: m.content,
+    }));
+    return {
+      compatData: ctx.extras.compatData ?? {},
+      globalVariables: variableStore.globalVariables,
+      chatVariables: variableStore.chatVariables,
+      compatVariables: getCompatVarRow(ctx.messageId, ctx.swipeId ?? 0),
+      character: {
+        id: character?.id ?? null,
+        name: character?.name ?? "",
+        avatar: character?.avatar ?? "",
+      },
+      message: {
+        id: ctx.messageId ?? null,
+        swipeId: ctx.swipeId ?? 0,
+        extra: chatStore.messages.find((item) => item.id === ctx.messageId)?.extra ?? {},
+      },
+      messages,
+    };
+  }
+
+  return {
+    chatId: ctx.chatId,
+    characterId: ctx.characterId,
+    characterName: character?.name ?? "",
+    messageCount: chatStore.messages.length,
+  };
+};
+
+export const getVariables: RpcHandler = () => {
+  const { globalVariables, chatVariables } = useVariableStore.getState();
+  return { global: globalVariables, chat: chatVariables };
+};
+
+export const requestWriteDone: RpcHandler = (_params, ctx) => {
+  if (ctx.extras.compatData) {
+    const data = ctx.extras.compatData as Record<string, unknown>;
+    return { statWithoutMeta: data.statWithoutMeta };
+  }
+  const { globalVariables, chatVariables } = useVariableStore.getState();
+  return { global: globalVariables, chat: chatVariables };
+};
+
+export const getVariable: RpcHandler = (params, ctx) => {
+  const name = typeof params.name === "string" ? params.name : "";
+  const scope = typeof params.scope === "string" ? params.scope : "auto";
+  if (!name) return undefined;
+
+  const variableStore = useVariableStore.getState();
+  const compatRow = getCompatVarRow(ctx.messageId, ctx.swipeId ?? 0);
+
+  if (scope === "compat") return compatRow[name];
+  if (scope === "chat") return variableStore.chatVariables[name];
+  if (scope === "global") return variableStore.globalVariables[name];
+  return (
+    compatRow[name] ?? variableStore.chatVariables[name] ?? variableStore.globalVariables[name]
+  );
+};
+
+export const setVariable: RpcHandler = async (params, ctx) => {
+  const name = typeof params.name === "string" ? params.name : "";
+  const scope = typeof params.scope === "string" ? params.scope : "compat";
+  if (!name) return false;
+
+  const variableStore = useVariableStore.getState();
+  const value = params.value;
+
+  if (scope === "global") {
+    variableStore.setGlobalVariable(name, String(value ?? ""));
+    return true;
+  }
+  if (scope === "chat") {
+    variableStore.setChatVariable(name, String(value ?? ""));
+    return true;
+  }
+
+  // compat scope: write to message extra
+  const messageId = ctx.messageId;
+  const swipeId = ctx.swipeId ?? 0;
+  if (!messageId) return false;
+
+  const { chatApi } = await import("@/lib/api/chat");
+  const message = useChatStore.getState().messages.find((item) => item.id === messageId);
+  if (!message) return false;
+
+  const extra = { ...message.extra };
+  const raw = extra[ST_COMPAT_VARS_KEY];
+  const rows = Array.isArray(raw) ? [...raw] : [];
+  while (rows.length <= swipeId) rows.push({});
+
+  const row =
+    rows[swipeId] && typeof rows[swipeId] === "object"
+      ? { ...(rows[swipeId] as Record<string, unknown>) }
+      : {};
+  row[name] = value;
+  rows[swipeId] = row;
+  extra[ST_COMPAT_VARS_KEY] = rows;
+
+  const updated = await chatApi.updateMessage(messageId, { extra });
+  useChatStore.setState((state) => ({
+    messages: state.messages.map((item) => (item.id === messageId ? updated : item)),
+  }));
+  return true;
+};

--- a/client/lib/compat-sandbox/rpc-handlers/index.ts
+++ b/client/lib/compat-sandbox/rpc-handlers/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Registers all built-in RPC handlers with the global registry.
+ * Call once at application startup (or sandbox panel mount).
+ */
+
+import type { RpcHandler } from "../rpc-registry";
+import { registerRpcAlias, registerRpcHandler } from "../rpc-registry";
+import { getContext, getVariables, requestWriteDone, getVariable, setVariable } from "./context";
+import { runSlashCommand } from "./commands";
+
+let registered = false;
+
+export const builtinRpcHandlerEntries: ReadonlyArray<readonly [string, RpcHandler]> = [
+  ["getContext", getContext],
+  ["getVariables", getVariables],
+  ["requestWriteDone", requestWriteDone],
+  ["getVariable", getVariable],
+  ["setVariable", setVariable],
+  ["runSlashCommand", runSlashCommand],
+] as const;
+
+export const builtinRpcAliasEntries: ReadonlyArray<readonly [string, string]> = [] as const;
+
+export function registerBuiltinHandlers(): void {
+  if (registered) return;
+  registered = true;
+
+  for (const [method, handler] of builtinRpcHandlerEntries) {
+    registerRpcHandler(method, handler);
+  }
+
+  for (const [alias, target] of builtinRpcAliasEntries) {
+    registerRpcAlias(alias, target);
+  }
+}
+
+export function resetBuiltinHandlersForTests(): void {
+  registered = false;
+}

--- a/client/lib/compat-sandbox/rpc-registry.ts
+++ b/client/lib/compat-sandbox/rpc-registry.ts
@@ -1,0 +1,69 @@
+/**
+ * RPC handler registry for the compat sandbox bridge.
+ *
+ * Both the sandbox panel (MessagePort bridge) and the per-message widget
+ * (postMessage bridge) dispatch RPC calls through this shared registry,
+ * keeping handler logic in one place and making new methods a one-liner
+ * registration.
+ */
+
+/** Snapshot of host-side state passed to every RPC handler. */
+export interface RpcContext {
+  chatId: number | null;
+  characterId: number | null;
+  /** Current message context (only set for per-message widget RPCs). */
+  messageId?: number;
+  swipeId?: number;
+  /** Opaque extras attached by the host component (e.g. compatData). */
+  extras: Record<string, unknown>;
+}
+
+export type RpcHandler = (
+  params: Record<string, unknown>,
+  ctx: RpcContext,
+) => Promise<unknown> | unknown;
+
+const handlers = new Map<string, RpcHandler>();
+
+export function registerRpcHandler(method: string, handler: RpcHandler): void {
+  handlers.set(method, handler);
+}
+
+export function registerRpcAlias(alias: string, target: string): void {
+  const handler = handlers.get(target);
+  if (handler) {
+    handlers.set(alias, handler);
+  }
+}
+
+export function getRpcHandler(method: string): RpcHandler | undefined {
+  return handlers.get(method);
+}
+
+export function hasRpcHandler(method: string): boolean {
+  return handlers.has(method);
+}
+
+export function listRpcMethods(): string[] {
+  return [...handlers.keys()];
+}
+
+export function clearRpcRegistryForTests(): void {
+  handlers.clear();
+}
+
+/**
+ * Dispatch an RPC call through the registry.
+ * Returns the handler result or throws if the method is unknown.
+ */
+export async function dispatchRpc(
+  method: string,
+  params: Record<string, unknown>,
+  ctx: RpcContext,
+): Promise<unknown> {
+  const handler = handlers.get(method);
+  if (!handler) {
+    throw new Error(`Unknown RPC method: ${method}`);
+  }
+  return handler(params, ctx);
+}


### PR DESCRIPTION
## 目的
把内建 RPC handler 注册方式从手写逐条调用整理成声明式注册表，降低扩展 iframe API 时的维护成本，并补上注册幂等性测试。

## 变更内容
- 将 builtin handler 注册改成 canonical handler 列表 + alias 列表驱动
- 保持 `registerBuiltinHandlers()` 对外接口不变，仅整理内部组织方式
- 为测试新增 registry reset 能力，方便隔离每个用例
- 补充 RPC registry 测试：注册、分发、幂等性、builtin surface 基线

## 接口与兼容性
- 不新增外部 RPC 方法
- 不改变 dispatch 协议和 bootstrap 行为
- 仅整理内建注册边界，为下一层扩展 surface 做准备

## 验证
- `pnpm --filter @arctravern/client exec vp test run lib/compat-sandbox/__tests__/rpc-registry.test.ts lib/compat-sandbox/__tests__/generation.test.ts`
- `pnpm --filter @arctravern/client exec tsc --noEmit`
