### PR TITLE
feat(compat): 扩展 iframe API 面并锁定回归测试

### DIFF
--- a/client/compat-sandbox.html
+++ b/client/compat-sandbox.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/client/components/chat/chat-panel-router.tsx
+++ b/client/components/chat/chat-panel-router.tsx
@@ -1,11 +1,25 @@
 "use client";
 
+import { useEffect } from "react";
 import { NativeChatPanel } from "./native-chat-panel";
 import { CompatSandboxPanel } from "./compat-sandbox-panel";
 import { useRuntimeMode } from "@/hooks/use-runtime-mode";
 
+const COMPAT_SANDBOX_PREFETCH_ID = "arctravern-compat-sandbox-prefetch";
+
 export function ChatPanelRouter() {
   const { runtimeMode } = useRuntimeMode();
+
+  useEffect(() => {
+    if (runtimeMode !== "compat-sandbox") return;
+    if (document.getElementById(COMPAT_SANDBOX_PREFETCH_ID)) return;
+    const link = document.createElement("link");
+    link.id = COMPAT_SANDBOX_PREFETCH_ID;
+    link.rel = "prefetch";
+    link.href = "/compat-sandbox.html";
+    link.as = "document";
+    document.head.appendChild(link);
+  }, [runtimeMode]);
 
   if (runtimeMode === "compat-sandbox") {
     return <CompatSandboxPanel />;

--- a/client/components/chat/compat-sandbox-message-view.tsx
+++ b/client/components/chat/compat-sandbox-message-view.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { lazy, Suspense } from "react";
+import { useTranslation } from "@/lib/i18n";
+import { isOpenUiLang } from "@/lib/openui";
+import type { PartialStructuredResponse } from "@/lib/openui/structured-types";
+import type { ActionEvent } from "@openuidev/react-lang";
+import { DotsLoader } from "@/components/ui/loader";
+import { useContentPreprocessor } from "@/hooks/use-content-preprocessor";
+import { useMessageScriptRuntime } from "@/hooks/use-message-script-runtime";
+import { CompatMarkdown } from "@/lib/compat/markdown-pipeline";
+import { prepareMessageViewModel } from "@/lib/compat/message-view-model";
+import {
+  ChainOfThought,
+  ChainOfThoughtContent,
+  ChainOfThoughtHeader,
+} from "@/components/ai-elements/chain-of-thought";
+
+const StructuredMessage = lazy(async () => {
+  const m = await import("./structured-message");
+  return { default: m.StructuredMessage };
+});
+
+const OpenUiMessage = lazy(async () => {
+  const m = await import("./openui-message");
+  return { default: m.OpenUiMessage };
+});
+
+const CompatWidgetMessage = lazy(async () => {
+  const m = await import("./compat-widget-message");
+  return { default: m.CompatWidgetMessage };
+});
+
+const markdownStyles =
+  "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-muted [&_pre]:p-3 [&_p]:leading-relaxed [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_li]:my-0.5";
+
+export interface CompatSandboxMessageViewProps {
+  messageId?: number;
+  role: "user" | "assistant" | "system" | "tool";
+  name?: string;
+  content: string;
+  reasoning?: string;
+  isStreaming?: boolean;
+  swipeId?: number;
+  swipes?: string[];
+  openUiEnabled?: boolean;
+  onOpenUiAction?: (event: ActionEvent) => void;
+  structuredContent?: PartialStructuredResponse | null;
+  onStructuredAction?: (label: string, value: string) => void;
+  onStructuredCommandAction?: (command: string) => void;
+  onWidgetSlashCommand?: (command: string) => Promise<void> | void;
+}
+
+/**
+ * Chat message body for the compat iframe only: same compat pipeline as MessageBubble
+ * but no action chrome, and heavy branches (structured / OpenUI / widgets) are lazy-loaded
+ * so the sandbox entry bundle stays small and runtime starts faster.
+ */
+export function CompatSandboxMessageView({
+  messageId,
+  role,
+  name,
+  content,
+  reasoning,
+  isStreaming,
+  swipeId = 0,
+  swipes = [],
+  openUiEnabled,
+  onOpenUiAction,
+  structuredContent,
+  onStructuredAction,
+  onStructuredCommandAction,
+  onWidgetSlashCommand,
+}: CompatSandboxMessageViewProps) {
+  const { t } = useTranslation();
+  const { formatAssistantForDisplay, preprocess } = useContentPreprocessor();
+  const isUser = role === "user";
+
+  const { display, scripts, segments, compatData, reasoningDisplay, hasWidgets } =
+    prepareMessageViewModel({
+      role,
+      content,
+      reasoning,
+      formatAssistantForDisplay,
+      preprocess,
+    });
+
+  const hasStructured = Boolean(structuredContent && structuredContent.blocks?.length);
+
+  useMessageScriptRuntime({
+    messageId,
+    swipeId,
+    scripts,
+    swipesLength: swipes.length,
+    enabled: Boolean(
+      !isStreaming && messageId && role === "assistant" && scripts.length > 0 && !hasStructured,
+    ),
+  });
+
+  if (isUser) {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[80%] rounded-2xl bg-secondary px-4 py-2.5 text-sm leading-relaxed text-secondary-foreground">
+          <CompatMarkdown content={content} className={markdownStyles} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="group/message">
+      {name && <p className="mb-1 text-xs font-medium text-muted-foreground">{name}</p>}
+
+      {reasoningDisplay && (
+        <ChainOfThought className="mb-2">
+          <ChainOfThoughtHeader>{t("chat.reasoning")}</ChainOfThoughtHeader>
+          <ChainOfThoughtContent>
+            <CompatMarkdown
+              content={reasoningDisplay}
+              className={`${markdownStyles} whitespace-pre-wrap break-words text-muted-foreground`}
+            />
+          </ChainOfThoughtContent>
+        </ChainOfThought>
+      )}
+
+      <div className="text-sm leading-relaxed">
+        <Suspense fallback={<DotsLoader size="sm" className="text-muted-foreground" />}>
+          {hasStructured ? (
+            <StructuredMessage
+              data={structuredContent!}
+              isStreaming={isStreaming}
+              onAction={onStructuredAction}
+              onCommandAction={onStructuredCommandAction}
+            />
+          ) : isStreaming && !content && !structuredContent ? (
+            <DotsLoader size="md" className="text-muted-foreground" />
+          ) : !isStreaming && hasWidgets ? (
+            <CompatWidgetMessage
+              messageId={messageId}
+              swipeId={swipeId}
+              segments={segments}
+              compatData={compatData}
+              markdownClassName={markdownStyles}
+              onWidgetSlashCommand={onWidgetSlashCommand}
+            />
+          ) : openUiEnabled && isOpenUiLang(display) ? (
+            <OpenUiMessage content={display} isStreaming={isStreaming} onAction={onOpenUiAction} />
+          ) : isStreaming ? (
+            <div className="whitespace-pre-wrap break-words">{display}</div>
+          ) : (
+            <CompatMarkdown content={display} className={markdownStyles} />
+          )}
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/client/components/chat/compat-sandbox-panel.tsx
+++ b/client/components/chat/compat-sandbox-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useChatStore } from "@/stores/chat-store";
 import { useCharacterStore } from "@/stores/character-store";
@@ -34,6 +34,11 @@ export function CompatSandboxPanel() {
     chatVariables: {} as Record<string, string>,
   });
   const [iframeLoaded, setIframeLoaded] = useState(false);
+
+  /** Ask iframe to emit compat:ready again (fixes StrictMode remount + listener race). */
+  const pingSandboxHandshake = useCallback(() => {
+    iframeRef.current?.contentWindow?.postMessage({ type: "compat:request-ready" }, "*");
+  }, []);
 
   const {
     messages,
@@ -178,35 +183,63 @@ export function CompatSandboxPanel() {
     selectedChar?.name,
   ]);
 
-  useEffect(() => {
-    if (!iframeLoaded || !iframeRef.current) return;
+  const bridgeActive = Boolean(selectedId && currentChatId && selectedChar);
+
+  useLayoutEffect(() => {
+    if (!bridgeActive || !iframeRef.current) return;
 
     registerBuiltinHandlers();
-    managerRef.current?.dispose();
-    managerRef.current = new BridgeManager(iframeRef.current, async (rpc) => {
-      const ctx: RpcContext = {
-        chatId: rpcContextRef.current.currentChatId,
-        characterId: rpcContextRef.current.selectedCharId,
-        extras: {},
-      };
-      try {
-        const result = await dispatchRpc(rpc.method, rpc.params ?? {}, ctx);
-        managerRef.current?.reply(rpc.id, result);
-      } catch (error) {
-        managerRef.current?.reply(
-          rpc.id,
-          undefined,
-          error instanceof Error ? error.message : String(error),
-        );
+
+    if (import.meta.env.DEV) {
+      console.log("[compat-host] useEffect mounted, listening for compat:ready");
+    }
+
+    function handleReady(event: MessageEvent) {
+      if (import.meta.env.DEV) {
+        console.log("[compat-host] window message:", event.data?.type, {
+          matchesReady: event.data?.type === "compat:ready",
+          sourceMatch: event.source === iframeRef.current?.contentWindow,
+          hasIframe: !!iframeRef.current,
+          hasContentWindow: !!iframeRef.current?.contentWindow,
+        });
       }
-    });
-    managerRef.current.connect();
+      if (event.data?.type !== "compat:ready" || event.source !== iframeRef.current?.contentWindow)
+        return;
+
+      if (import.meta.env.DEV) {
+        console.log("[compat-host] compat:ready received, connecting bridge");
+      }
+      managerRef.current?.dispose();
+      managerRef.current = new BridgeManager(iframeRef.current!, async (rpc) => {
+        const ctx: RpcContext = {
+          chatId: rpcContextRef.current.currentChatId,
+          characterId: rpcContextRef.current.selectedCharId,
+          extras: {},
+        };
+        try {
+          const result = await dispatchRpc(rpc.method, rpc.params ?? {}, ctx);
+          managerRef.current?.reply(rpc.id, result);
+        } catch (error) {
+          managerRef.current?.reply(
+            rpc.id,
+            undefined,
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      });
+      managerRef.current.connect();
+      setIframeLoaded(true);
+    }
+
+    window.addEventListener("message", handleReady);
+    pingSandboxHandshake();
 
     return () => {
+      window.removeEventListener("message", handleReady);
       managerRef.current?.dispose();
       managerRef.current = null;
     };
-  }, [iframeLoaded, runSlashCommand]);
+  }, [bridgeActive, pingSandboxHandshake]);
 
   const snapshot = useMemo<CompatSandboxSnapshot | null>(() => {
     if (!currentChatId || !selectedChar) return null;
@@ -226,6 +259,8 @@ export function CompatSandboxPanel() {
       globalVariables,
       chatVariables,
       openUiEnabled: connection.openUiEnabled,
+      isGenerating,
+      generationType,
       streamingMessageId,
       streamingContent,
       streamingReasoning,
@@ -249,7 +284,7 @@ export function CompatSandboxPanel() {
   useEffect(() => {
     if (!snapshot || !managerRef.current) return;
     managerRef.current.sync(snapshot);
-  }, [snapshot]);
+  }, [snapshot, iframeLoaded]);
 
   if (!selectedId || !currentChatId || !selectedChar) {
     return <ChatWelcomeScreen />;
@@ -267,10 +302,10 @@ export function CompatSandboxPanel() {
         <iframe
           ref={iframeRef}
           title="Compat Sandbox"
-          sandbox="allow-scripts allow-forms allow-modals allow-popups"
+          sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
           className="h-full w-full border-0"
           src="/compat-sandbox.html"
-          onLoad={() => setIframeLoaded(true)}
+          onLoad={pingSandboxHandshake}
         />
       </div>
 

--- a/client/components/ui/sidebar.tsx
+++ b/client/components/ui/sidebar.tsx
@@ -503,7 +503,7 @@ function SidebarMenuButton({
       },
       props,
     ),
-    render: !tooltip ? render : TooltipTrigger,
+    render: !tooltip ? render : (props) => <TooltipTrigger {...props} />,
     state: {
       slot: "sidebar-menu-button",
       sidebar: "menu-button",

--- a/client/hooks/use-generation-config.ts
+++ b/client/hooks/use-generation-config.ts
@@ -4,7 +4,7 @@ import type { PromptComponent } from "@/stores/prompt-manager-store";
 import type { CustomApiFormat } from "@/stores/connection-store";
 import type { Provider } from "@/lib/api/types";
 
-interface ConnectionConfig {
+export interface ConnectionConfig {
   provider: Provider;
   model: string;
   temperature: number;
@@ -19,93 +19,97 @@ interface ConnectionConfig {
   customApiFormat: CustomApiFormat;
 }
 
-interface SelectedCharacterRef {
+export interface SelectedCharacterRef {
   worldInfoBookId?: number | null;
 }
 
-export function useGenerationConfig({
-  connection,
-  promptComponents,
-  activeBookIds,
-  selectedChar,
-}: {
+interface GenerationConfigArgs {
   connection: ConnectionConfig;
   promptComponents: PromptComponent[];
   activeBookIds: number[];
   selectedChar?: SelectedCharacterRef;
-}) {
+}
+
+export function buildGenerationConfig({
+  connection,
+  promptComponents,
+  activeBookIds,
+  selectedChar,
+}: GenerationConfigArgs) {
   const openUiEnabled = connection.openUiEnabled;
 
-  const promptOrder = useMemo(() => {
-    const order = [...promptComponents]
-      .sort((a, b) => a.position - b.position)
-      .map((c) => ({ identifier: c.id, enabled: c.enabled }));
-    if (openUiEnabled) {
-      order.push({ identifier: "openui_instructions", enabled: true });
-    }
-    return order;
-  }, [promptComponents, openUiEnabled]);
+  const promptOrder = [...promptComponents]
+    .sort((a, b) => a.position - b.position)
+    .map((c) => ({ identifier: c.id, enabled: c.enabled }));
+  if (openUiEnabled) {
+    promptOrder.push({ identifier: "openui_instructions", enabled: true });
+  }
 
-  const customPrompts = useMemo(() => {
-    const prompts = promptComponents
-      .filter((c) => c.enabled && c.content !== undefined && c.content.trim() !== "")
-      .map((c) => ({
-        identifier: c.id,
-        role: c.role,
-        content: c.content!,
-      }));
-    if (openUiEnabled) {
-      prompts.push({
-        identifier: "openui_instructions",
-        role: "system" as const,
-        content: getOpenUiSystemPrompt(),
-      });
-    }
-    return prompts;
-  }, [promptComponents, openUiEnabled]);
+  const customPrompts = promptComponents
+    .filter((c) => c.enabled && c.content !== undefined && c.content.trim() !== "")
+    .map((c) => ({
+      identifier: c.id,
+      role: c.role,
+      content: c.content!,
+    }));
+  if (openUiEnabled) {
+    customPrompts.push({
+      identifier: "openui_instructions",
+      role: "system" as const,
+      content: getOpenUiSystemPrompt(),
+    });
+  }
 
-  const generationConfig = useMemo(
-    () => ({
-      provider: connection.provider,
-      model: connection.model,
-      temperature: connection.temperature,
-      maxTokens: connection.maxTokens,
-      topP: connection.topP,
-      topK: connection.topK,
-      frequencyPenalty: connection.frequencyPenalty,
-      presencePenalty: connection.presencePenalty,
-      reverseProxy: connection.reverseProxy || undefined,
-      maxContext: connection.maxContext,
-      promptOrder,
-      customPrompts,
-      structuredOutput: openUiEnabled,
-      customApiFormat: connection.provider === "custom" ? connection.customApiFormat : undefined,
-      worldInfoBookIds: (() => {
-        const ids = [...activeBookIds];
-        const charBookId = selectedChar?.worldInfoBookId;
-        if (charBookId && !ids.includes(charBookId)) ids.unshift(charBookId);
-        return ids.length > 0 ? ids : undefined;
-      })(),
-    }),
-    [
-      activeBookIds,
-      connection.customApiFormat,
-      connection.frequencyPenalty,
-      connection.maxContext,
-      connection.maxTokens,
-      connection.model,
-      connection.presencePenalty,
-      connection.provider,
-      connection.reverseProxy,
-      connection.temperature,
-      connection.topK,
-      connection.topP,
-      customPrompts,
-      openUiEnabled,
-      promptOrder,
-      selectedChar?.worldInfoBookId,
-    ],
-  );
+  const generationConfig = {
+    provider: connection.provider,
+    model: connection.model,
+    temperature: connection.temperature,
+    maxTokens: connection.maxTokens,
+    topP: connection.topP,
+    // Gemini via @ai-sdk/google does not accept unified `topK`; omit on the wire (server also strips).
+    topK:
+      connection.provider === "google" ||
+      (connection.provider === "custom" && connection.customApiFormat === "google")
+        ? undefined
+        : connection.topK,
+    frequencyPenalty: connection.frequencyPenalty,
+    presencePenalty: connection.presencePenalty,
+    reverseProxy: connection.reverseProxy || undefined,
+    maxContext: connection.maxContext,
+    promptOrder,
+    customPrompts,
+    structuredOutput: openUiEnabled,
+    customApiFormat: connection.provider === "custom" ? connection.customApiFormat : undefined,
+    worldInfoBookIds: (() => {
+      const ids = [...activeBookIds];
+      const charBookId = selectedChar?.worldInfoBookId;
+      if (charBookId && !ids.includes(charBookId)) ids.unshift(charBookId);
+      return ids.length > 0 ? ids : undefined;
+    })(),
+  };
 
   return { generationConfig, promptOrder, customPrompts };
+}
+
+export function useGenerationConfig(args: GenerationConfigArgs) {
+  return useMemo(
+    () => buildGenerationConfig(args),
+    [
+      args.activeBookIds,
+      args.connection.customApiFormat,
+      args.connection.frequencyPenalty,
+      args.connection.maxContext,
+      args.connection.maxTokens,
+      args.connection.model,
+      args.connection.openUiEnabled,
+      args.connection.presencePenalty,
+      args.connection.provider,
+      args.connection.reverseProxy,
+      args.connection.temperature,
+      args.connection.topK,
+      args.connection.topP,
+      args.promptComponents,
+      args.selectedChar?.worldInfoBookId,
+    ],
+  );
 }

--- a/client/hooks/use-settings-panel-controller.ts
+++ b/client/hooks/use-settings-panel-controller.ts
@@ -26,6 +26,7 @@ export function useSettingsPanelController(t: (key: string) => string) {
     model,
     reverseProxy,
     customModels,
+    customApiFormat,
     topK,
     frequencyPenalty,
     presencePenalty,
@@ -36,6 +37,7 @@ export function useSettingsPanelController(t: (key: string) => string) {
       model: s.model,
       reverseProxy: s.reverseProxy,
       customModels: s.customModels,
+      customApiFormat: s.customApiFormat,
       topK: s.topK,
       frequencyPenalty: s.frequencyPenalty,
       presencePenalty: s.presencePenalty,
@@ -103,10 +105,14 @@ export function useSettingsPanelController(t: (key: string) => string) {
         temperature: 0.1,
         maxTokens: 16,
         topP: 1,
-        topK,
+        topK:
+          provider === "google" || (provider === "custom" && customApiFormat === "google")
+            ? undefined
+            : topK,
         frequencyPenalty,
         presencePenalty,
         reverseProxy: reverseProxy || undefined,
+        customApiFormat: provider === "custom" ? customApiFormat : undefined,
       });
       setConnectionStatus("ok", t("settings.connectionSuccess"));
       toast.success({ title: t("settings.connectionSuccess") });
@@ -120,6 +126,7 @@ export function useSettingsPanelController(t: (key: string) => string) {
     model,
     reverseProxy,
     customModels,
+    customApiFormat,
     topK,
     frequencyPenalty,
     presencePenalty,

--- a/client/lib/api/types.ts
+++ b/client/lib/api/types.ts
@@ -30,4 +30,5 @@ export interface CompletionRequest {
   jsonSchema?: { name: string; description?: string; value: object };
   reasoningEffort?: string;
   reverseProxy?: string;
+  customApiFormat?: "openai-compatible" | "google" | "openai" | "anthropic";
 }

--- a/client/lib/compat-sandbox/__tests__/generation.test.ts
+++ b/client/lib/compat-sandbox/__tests__/generation.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RpcContext } from "../rpc-registry";
+
+const { generationConfig, chatState } = vi.hoisted(() => ({
+  generationConfig: { provider: "openai", model: "gpt-5.2" },
+  chatState: {
+    isGenerating: false,
+    sendMessage: vi.fn(),
+    continueMessage: vi.fn(),
+    impersonate: vi.fn(),
+    generateSwipe: vi.fn(),
+    regenerate: vi.fn(),
+    stopGeneration: vi.fn(),
+    generationType: null,
+    streamingContent: "",
+    streamingReasoning: "",
+  },
+}));
+
+vi.mock("@/stores/chat-store", () => ({
+  useChatStore: {
+    getState: () => chatState,
+  },
+}));
+
+vi.mock("@/stores/character-store", () => ({
+  useCharacterStore: {
+    getState: () => ({
+      selectedId: 1,
+      characters: [{ id: 1, worldInfoBookId: 7 }],
+    }),
+  },
+}));
+
+vi.mock("@/stores/connection-store", () => ({
+  useConnectionStore: {
+    getState: () => ({
+      provider: "openai",
+      model: "gpt-5.2",
+    }),
+  },
+}));
+
+vi.mock("@/stores/prompt-manager-store", () => ({
+  usePromptManagerStore: {
+    getState: () => ({
+      components: [],
+    }),
+  },
+}));
+
+vi.mock("@/stores/world-info-store", () => ({
+  useWorldInfoStore: {
+    getState: () => ({
+      activeBookIds: [],
+    }),
+  },
+}));
+
+vi.mock("@/hooks/use-generation-config", () => ({
+  buildGenerationConfig: vi.fn(() => ({
+    generationConfig,
+    promptOrder: [],
+    customPrompts: [],
+  })),
+}));
+
+import { generate } from "../rpc-handlers/generation";
+
+const ctx: RpcContext = {
+  chatId: 1,
+  characterId: 1,
+  extras: {},
+};
+
+describe("compat sandbox generation RPC", () => {
+  beforeEach(() => {
+    chatState.isGenerating = false;
+    chatState.sendMessage.mockReset();
+    chatState.continueMessage.mockReset();
+    chatState.impersonate.mockReset();
+    chatState.generateSwipe.mockReset();
+    chatState.regenerate.mockReset();
+    chatState.stopGeneration.mockReset();
+  });
+
+  it('runs a normal generation through sendMessage instead of returning an intent', async () => {
+    chatState.sendMessage.mockResolvedValue(undefined);
+
+    await expect(generate({ type: "normal", message: "hello" }, ctx)).resolves.toBe(true);
+
+    expect(chatState.sendMessage).toHaveBeenCalledWith("hello", generationConfig);
+  });
+
+  it("runs a non-normal generation through the matching store action", async () => {
+    chatState.continueMessage.mockResolvedValue(undefined);
+
+    await expect(generate({ type: "continue" }, ctx)).resolves.toBe(true);
+
+    expect(chatState.continueMessage).toHaveBeenCalledWith(generationConfig);
+  });
+
+  it("rejects when a generation is already in progress", async () => {
+    chatState.isGenerating = true;
+
+    await expect(generate({ type: "normal", message: "hello" }, ctx)).rejects.toThrow(
+      "Generation already in progress",
+    );
+  });
+});

--- a/client/lib/compat-sandbox/__tests__/rpc-registry.test.ts
+++ b/client/lib/compat-sandbox/__tests__/rpc-registry.test.ts
@@ -1,4 +1,60 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../rpc-handlers/context", () => ({
+  getContext: vi.fn(),
+  getVariables: vi.fn(),
+  requestWriteDone: vi.fn(),
+  getVariable: vi.fn(),
+  setVariable: vi.fn(),
+}));
+
+vi.mock("../rpc-handlers/commands", () => ({
+  runSlashCommand: vi.fn(),
+}));
+
+vi.mock("../rpc-handlers/messages", () => ({
+  getChatMessages: vi.fn(),
+  getLastMessage: vi.fn(),
+  getMessage: vi.fn(),
+  getLastMessageId: vi.fn(),
+  editMessage: vi.fn(),
+  deleteMessageHandler: vi.fn(),
+  addMessage: vi.fn(),
+  getMessageCount: vi.fn(),
+}));
+
+vi.mock("../rpc-handlers/characters", () => ({
+  getCharacter: vi.fn(),
+  getCharacterList: vi.fn(),
+  getCurrentCharacterName: vi.fn(),
+  getCharacterAvatarUrl: vi.fn(),
+}));
+
+vi.mock("../rpc-handlers/generation", () => ({
+  isGenerating: vi.fn(),
+  stopGeneration: vi.fn(),
+  generate: vi.fn(),
+  getGenerationType: vi.fn(),
+  getStreamingContent: vi.fn(),
+}));
+
+vi.mock("../rpc-handlers/connection", () => ({
+  getConnectionSettings: vi.fn(),
+  getProvider: vi.fn(),
+  getModel: vi.fn(),
+}));
+
+vi.mock("../rpc-handlers/worldinfo", () => ({
+  getWorldInfoBooks: vi.fn(),
+  getWorldInfoEntries: vi.fn(),
+  getActiveWorldInfoBookIds: vi.fn(),
+}));
+
+vi.mock("../rpc-handlers/globals", () => ({
+  initializeGlobal: vi.fn(),
+  waitGlobalInitialized: vi.fn(),
+  getGlobal: vi.fn(),
+}));
 import {
   clearRpcRegistryForTests,
   registerRpcHandler,
@@ -10,6 +66,7 @@ import {
   type RpcContext,
 } from "../rpc-registry";
 import {
+  builtinRpcAliasEntries,
   builtinRpcHandlerEntries,
   registerBuiltinHandlers,
   resetBuiltinHandlersForTests,
@@ -76,17 +133,19 @@ describe("rpc-registry", () => {
       expect(methods).toContain(method);
     }
 
-    expect(methods).toHaveLength(builtinRpcHandlerEntries.length);
+    for (const [alias] of builtinRpcAliasEntries) {
+      expect(methods).toContain(alias);
+    }
+
+    expect(methods).toHaveLength(builtinRpcHandlerEntries.length + builtinRpcAliasEntries.length);
   });
 
-  it("dispatches builtins after registration", async () => {
+  it("registers representative compat aliases", async () => {
     registerBuiltinHandlers();
 
-    await expect(dispatchRpc("getContext", {}, stubCtx)).resolves.toEqual(
-      expect.objectContaining({
-        chatId: stubCtx.chatId,
-        characterId: stubCtx.characterId,
-      }),
-    );
+    expect(getRpcHandler("triggerSlash")).toBe(getRpcHandler("runSlashCommand"));
+    expect(getRpcHandler("getCharacterNames")).toBe(getRpcHandler("getCharacterList"));
+    expect(getRpcHandler("getCharData")).toBe(getRpcHandler("getCharacter"));
+    expect(getRpcHandler("stopAllGeneration")).toBe(getRpcHandler("stopGeneration"));
   });
 });

--- a/client/lib/compat-sandbox/bridge-client.ts
+++ b/client/lib/compat-sandbox/bridge-client.ts
@@ -36,8 +36,16 @@ export function useBridgeClient() {
 
   useEffect(() => {
     const handleWindowMessage = (event: MessageEvent) => {
+      if (import.meta.env.DEV) {
+        console.log("[bridge-client] window message:", event.data?.type, {
+          hasPorts: !!event.ports?.[0],
+        });
+      }
       if (event.data?.type !== "compat:port-transfer" || !event.ports?.[0]) return;
 
+      if (import.meta.env.DEV) {
+        console.log("[bridge-client] port-transfer received, setting up port");
+      }
       const port = event.ports[0];
       portRef.current = port;
       port.onmessage = (portEvent: MessageEvent<HostToSandboxMessage | SandboxToHostMessage>) => {
@@ -46,6 +54,12 @@ export function useBridgeClient() {
 
         switch (data.type) {
           case "session:init":
+            if (import.meta.env.DEV) {
+              console.log("[bridge-client] session:init received", {
+                chatId: data.payload.chatId,
+                messageCount: data.payload.messages?.length,
+              });
+            }
             setState({
               session: data.payload,
               streamingMessageId: -1,
@@ -82,30 +96,41 @@ export function useBridgeClient() {
             });
             break;
           case "message:append":
-            setState((current) => ({
-              ...current,
-              streamingMessageId: data.payload.messageId,
-              streamingContent:
-                data.payload.delta.content !== undefined &&
-                current.streamingMessageId === data.payload.messageId &&
-                current.streamingContent &&
-                data.payload.delta.content &&
-                !data.payload.delta.content.startsWith(current.streamingContent)
-                  ? `${current.streamingContent}${data.payload.delta.content}`
-                  : (data.payload.delta.content ?? current.streamingContent),
-              streamingReasoning:
-                data.payload.delta.reasoning !== undefined &&
-                current.streamingMessageId === data.payload.messageId &&
-                current.streamingReasoning &&
-                data.payload.delta.reasoning &&
-                !data.payload.delta.reasoning.startsWith(current.streamingReasoning)
-                  ? `${current.streamingReasoning}${data.payload.delta.reasoning}`
-                  : (data.payload.delta.reasoning ?? current.streamingReasoning),
-              streamingStructured:
-                data.payload.delta.structured !== undefined
-                  ? data.payload.delta.structured
-                  : current.streamingStructured,
-            }));
+            setState((current) => {
+              const mid = data.payload.messageId;
+              if (current.streamingMessageId !== mid) {
+                return {
+                  ...current,
+                  streamingMessageId: mid,
+                  streamingContent: data.payload.delta.content ?? "",
+                  streamingReasoning: data.payload.delta.reasoning ?? "",
+                  streamingStructured:
+                    data.payload.delta.structured !== undefined
+                      ? data.payload.delta.structured
+                      : current.streamingStructured,
+                };
+              }
+              const prevC = current.streamingContent;
+              const prevR = current.streamingReasoning;
+              const dC = data.payload.delta.content;
+              const dR = data.payload.delta.reasoning;
+              return {
+                ...current,
+                streamingMessageId: mid,
+                streamingContent:
+                  dC !== undefined && prevC.length > 0 && dC && !dC.startsWith(prevC)
+                    ? `${prevC}${dC}`
+                    : (dC ?? prevC),
+                streamingReasoning:
+                  dR !== undefined && prevR.length > 0 && dR && !dR.startsWith(prevR)
+                    ? `${prevR}${dR}`
+                    : (dR ?? prevR),
+                streamingStructured:
+                  data.payload.delta.structured !== undefined
+                    ? data.payload.delta.structured
+                    : current.streamingStructured,
+              };
+            });
             break;
           case "message:finalize":
             setState((current) =>
@@ -134,6 +159,11 @@ export function useBridgeClient() {
                         data.payload.globalVariables ?? current.session.globalVariables,
                       chatVariables: data.payload.chatVariables ?? current.session.chatVariables,
                       openUiEnabled: data.payload.openUiEnabled ?? current.session.openUiEnabled,
+                      isGenerating: data.payload.isGenerating ?? current.session.isGenerating,
+                      generationType:
+                        data.payload.generationType !== undefined
+                          ? data.payload.generationType
+                          : current.session.generationType,
                     },
                   }
                 : current,
@@ -156,6 +186,10 @@ export function useBridgeClient() {
     };
 
     window.addEventListener("message", handleWindowMessage);
+
+    // Notify the host that the bridge client is ready to receive the port.
+    window.parent.postMessage({ type: "compat:ready" }, "*");
+
     return () => {
       window.removeEventListener("message", handleWindowMessage);
       portRef.current?.close();

--- a/client/lib/compat-sandbox/bridge-manager.ts
+++ b/client/lib/compat-sandbox/bridge-manager.ts
@@ -18,6 +18,15 @@ function sameMessage(a: Message, b: Message): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
+/** Same ordered message ids — if false, iframe list cannot be repaired by upserts alone. */
+function sameMessageIdOrder(prev: Message[], next: Message[]): boolean {
+  if (prev.length !== next.length) return false;
+  for (let i = 0; i < prev.length; i += 1) {
+    if (prev[i].id !== next[i].id) return false;
+  }
+  return true;
+}
+
 function diffStreaming(
   previous: CompatSandboxSnapshot | null,
   next: CompatSandboxSnapshot,
@@ -62,6 +71,9 @@ export class BridgeManager {
 
   connect() {
     const contentWindow = this.iframe.contentWindow;
+    if (import.meta.env.DEV) {
+      console.log("[bridge-manager] connect() called", { hasContentWindow: !!contentWindow });
+    }
     if (!contentWindow) return;
 
     const channel = new MessageChannel();
@@ -75,6 +87,9 @@ export class BridgeManager {
     this.port.start();
 
     contentWindow.postMessage({ type: "compat:port-transfer" }, "*", [channel.port2]);
+    if (import.meta.env.DEV) {
+      console.log("[bridge-manager] port-transfer sent to sandbox");
+    }
   }
 
   dispose() {
@@ -96,7 +111,19 @@ export class BridgeManager {
   sync(next: CompatSandboxSnapshot) {
     if (!this.port) return;
 
+    if (this.snapshot && this.snapshot.chatId !== next.chatId) {
+      this.snapshot = null;
+      this.sync(next);
+      return;
+    }
+
     if (!this.snapshot) {
+      if (import.meta.env.DEV) {
+        console.log("[bridge-manager] sending session:init", {
+          chatId: next.chatId,
+          messageCount: next.messages.length,
+        });
+      }
       this.port.postMessage({
         type: "session:init",
         payload: {
@@ -107,6 +134,8 @@ export class BridgeManager {
           globalVariables: next.globalVariables,
           chatVariables: next.chatVariables,
           openUiEnabled: next.openUiEnabled,
+          isGenerating: next.isGenerating,
+          generationType: next.generationType,
         },
       } satisfies HostToSandboxMessage);
       this.snapshot = next;
@@ -124,7 +153,9 @@ export class BridgeManager {
       JSON.stringify(this.snapshot.globalVariables) !== JSON.stringify(next.globalVariables) ||
       JSON.stringify(this.snapshot.chatVariables) !== JSON.stringify(next.chatVariables) ||
       this.snapshot.openUiEnabled !== next.openUiEnabled ||
-      JSON.stringify(this.snapshot.character) !== JSON.stringify(next.character)
+      JSON.stringify(this.snapshot.character) !== JSON.stringify(next.character) ||
+      this.snapshot.isGenerating !== next.isGenerating ||
+      this.snapshot.generationType !== next.generationType
     ) {
       this.port.postMessage({
         type: "vars:patch",
@@ -134,6 +165,8 @@ export class BridgeManager {
           globalVariables: next.globalVariables,
           chatVariables: next.chatVariables,
           openUiEnabled: next.openUiEnabled,
+          isGenerating: next.isGenerating,
+          generationType: next.generationType,
         },
       } satisfies HostToSandboxMessage);
     }
@@ -141,7 +174,9 @@ export class BridgeManager {
     const previousMessages = new Map(
       this.snapshot.messages.map((message) => [message.id, message]),
     );
-    let requiresFullReset = next.messages.length < this.snapshot.messages.length;
+    let requiresFullReset =
+      next.messages.length < this.snapshot.messages.length ||
+      !sameMessageIdOrder(this.snapshot.messages, next.messages);
 
     if (!requiresFullReset) {
       for (const message of next.messages) {

--- a/client/lib/compat-sandbox/protocol.ts
+++ b/client/lib/compat-sandbox/protocol.ts
@@ -1,5 +1,6 @@
 import type { Character } from "@/lib/api/character";
 import type { Message } from "@/lib/api/chat";
+import type { GenerationType } from "@/lib/api/types";
 import type { RegexScriptData } from "@/lib/compat/regex-engine";
 import type { PartialStructuredResponse } from "@/lib/openui/structured-types";
 
@@ -11,6 +12,9 @@ export interface CompatSandboxSession {
   globalVariables: Record<string, string>;
   chatVariables: Record<string, string>;
   openUiEnabled: boolean;
+  /** Mirrors host chat-store so the iframe can show loading/streaming UI. */
+  isGenerating: boolean;
+  generationType: GenerationType | null;
 }
 
 export interface CompatStreamingDelta {
@@ -44,7 +48,13 @@ export type HostToSandboxMessage =
       payload: Partial<
         Pick<
           CompatSandboxSession,
-          "character" | "globalScripts" | "globalVariables" | "chatVariables" | "openUiEnabled"
+          | "character"
+          | "globalScripts"
+          | "globalVariables"
+          | "chatVariables"
+          | "openUiEnabled"
+          | "isGenerating"
+          | "generationType"
         >
       >;
     };

--- a/client/lib/compat-sandbox/rpc-handlers/characters.ts
+++ b/client/lib/compat-sandbox/rpc-handlers/characters.ts
@@ -1,0 +1,57 @@
+/**
+ * RPC handlers: character data access.
+ */
+
+import { useCharacterStore } from "@/stores/character-store";
+import { characterApi } from "@/lib/api/character";
+import type { RpcHandler } from "../rpc-registry";
+
+/** getCharacter({ id? }) — returns current character if no id given */
+export const getCharacter: RpcHandler = (params, ctx) => {
+  const store = useCharacterStore.getState();
+  const id = typeof params.id === "number" ? params.id : ctx.characterId;
+  const character = store.characters.find((c) => c.id === id);
+  if (!character) return null;
+
+  return {
+    id: character.id,
+    name: character.name,
+    avatar: character.avatar,
+    description: character.description,
+    personality: character.personality,
+    firstMes: character.firstMes,
+    mesExample: character.mesExample,
+    scenario: character.scenario,
+    systemPrompt: character.systemPrompt,
+    postHistoryInstructions: character.postHistoryInstructions,
+    alternateGreetings: character.alternateGreetings,
+    creator: character.creator,
+    tags: character.tags,
+    extensions: character.extensions,
+  };
+};
+
+/** getCharacterList() */
+export const getCharacterList: RpcHandler = () => {
+  return useCharacterStore.getState().characters.map((c) => ({
+    id: c.id,
+    name: c.name,
+    avatar: c.avatar,
+    creator: c.creator,
+    tags: c.tags,
+  }));
+};
+
+/** getCurrentCharacterName() */
+export const getCurrentCharacterName: RpcHandler = (_params, ctx) => {
+  const store = useCharacterStore.getState();
+  const character = store.characters.find((c) => c.id === ctx.characterId);
+  return character?.name ?? "";
+};
+
+/** getCharacterAvatarUrl({ id? }) */
+export const getCharacterAvatarUrl: RpcHandler = (params, ctx) => {
+  const id = typeof params.id === "number" ? params.id : ctx.characterId;
+  if (id == null) return null;
+  return characterApi.avatarUrl(id);
+};

--- a/client/lib/compat-sandbox/rpc-handlers/connection.ts
+++ b/client/lib/compat-sandbox/rpc-handlers/connection.ts
@@ -1,0 +1,33 @@
+/**
+ * RPC handlers: connection/model settings (read-only).
+ */
+
+import { useConnectionStore } from "@/stores/connection-store";
+import type { RpcHandler } from "../rpc-registry";
+
+/** getConnectionSettings() */
+export const getConnectionSettings: RpcHandler = () => {
+  const s = useConnectionStore.getState();
+  return {
+    provider: s.provider,
+    model: s.model,
+    temperature: s.temperature,
+    maxTokens: s.maxTokens,
+    topP: s.topP,
+    topK: s.topK,
+    frequencyPenalty: s.frequencyPenalty,
+    presencePenalty: s.presencePenalty,
+    maxContext: s.maxContext,
+    openUiEnabled: s.openUiEnabled,
+  };
+};
+
+/** getProvider() */
+export const getProvider: RpcHandler = () => {
+  return useConnectionStore.getState().provider;
+};
+
+/** getModel() */
+export const getModel: RpcHandler = () => {
+  return useConnectionStore.getState().model;
+};

--- a/client/lib/compat-sandbox/rpc-handlers/generation.ts
+++ b/client/lib/compat-sandbox/rpc-handlers/generation.ts
@@ -1,16 +1,29 @@
-/**
- * RPC handlers: AI generation control.
- */
+"use client";
 
+import { buildGenerationConfig } from "@/hooks/use-generation-config";
+import { useCharacterStore } from "@/stores/character-store";
 import { useChatStore } from "@/stores/chat-store";
+import { useConnectionStore } from "@/stores/connection-store";
+import { usePromptManagerStore } from "@/stores/prompt-manager-store";
+import { useWorldInfoStore } from "@/stores/world-info-store";
 import type { RpcHandler } from "../rpc-registry";
 
-/** isGenerating() */
+function getCurrentGenerationConfig() {
+  const { selectedId, characters } = useCharacterStore.getState();
+  const selectedChar = characters.find((character) => character.id === selectedId);
+
+  return buildGenerationConfig({
+    connection: useConnectionStore.getState(),
+    promptComponents: usePromptManagerStore.getState().components,
+    activeBookIds: useWorldInfoStore.getState().activeBookIds,
+    selectedChar,
+  }).generationConfig;
+}
+
 export const isGenerating: RpcHandler = () => {
   return useChatStore.getState().isGenerating;
 };
 
-/** stopGeneration() */
 export const stopGeneration: RpcHandler = async () => {
   await useChatStore.getState().stopGeneration();
   return true;
@@ -19,12 +32,8 @@ export const stopGeneration: RpcHandler = async () => {
 /**
  * generate({ type?, message? })
  *
- * Triggers a generation through the native chat store. The generation config
- * is not passed from the script — it uses whatever the user has configured
- * in the connection settings. Scripts can only control the type and message.
- *
- * This is intentionally limited: we don't expose the full GenerationConfig
- * to prevent scripts from overriding the user's provider/model settings.
+ * Triggers generation through the host chat store using the current
+ * connection, prompt, and world-info state from Zustand.
  */
 export const generate: RpcHandler = async (params) => {
   const type = typeof params.type === "string" ? params.type : "normal";
@@ -35,26 +44,38 @@ export const generate: RpcHandler = async (params) => {
     throw new Error("Generation already in progress");
   }
 
-  // Delegate to the store's sendMessage for normal type, which handles
-  // the full config internally. For other types we'd need the config
-  // which is only available in the React component layer.
-  // For now, only "normal" is supported from scripts.
-  if (type === "normal" && message) {
-    // We can't call sendMessage directly because it requires GenerationConfig.
-    // Instead, signal that we want generation by returning the intent —
-    // the host component will handle it.
-    return { intent: "generate", type, message };
-  }
+  const generationConfig = getCurrentGenerationConfig();
 
-  return { intent: "generate", type, message };
+  switch (type) {
+    case "normal": {
+      const trimmedMessage = message?.trim();
+      if (!trimmedMessage) {
+        throw new Error("Generation message is required");
+      }
+      await store.sendMessage(trimmedMessage, generationConfig);
+      return true;
+    }
+    case "continue":
+      await store.continueMessage(generationConfig);
+      return true;
+    case "impersonate":
+      await store.impersonate(generationConfig);
+      return true;
+    case "swipe":
+      await store.generateSwipe(generationConfig);
+      return true;
+    case "regenerate":
+      await store.regenerate(generationConfig);
+      return true;
+    default:
+      throw new Error(`Unsupported generation type: ${type}`);
+  }
 };
 
-/** getGenerationType() */
 export const getGenerationType: RpcHandler = () => {
   return useChatStore.getState().generationType;
 };
 
-/** getStreamingContent() */
 export const getStreamingContent: RpcHandler = () => {
   const store = useChatStore.getState();
   return {

--- a/client/lib/compat-sandbox/rpc-handlers/generation.ts
+++ b/client/lib/compat-sandbox/rpc-handlers/generation.ts
@@ -1,0 +1,65 @@
+/**
+ * RPC handlers: AI generation control.
+ */
+
+import { useChatStore } from "@/stores/chat-store";
+import type { RpcHandler } from "../rpc-registry";
+
+/** isGenerating() */
+export const isGenerating: RpcHandler = () => {
+  return useChatStore.getState().isGenerating;
+};
+
+/** stopGeneration() */
+export const stopGeneration: RpcHandler = async () => {
+  await useChatStore.getState().stopGeneration();
+  return true;
+};
+
+/**
+ * generate({ type?, message? })
+ *
+ * Triggers a generation through the native chat store. The generation config
+ * is not passed from the script — it uses whatever the user has configured
+ * in the connection settings. Scripts can only control the type and message.
+ *
+ * This is intentionally limited: we don't expose the full GenerationConfig
+ * to prevent scripts from overriding the user's provider/model settings.
+ */
+export const generate: RpcHandler = async (params) => {
+  const type = typeof params.type === "string" ? params.type : "normal";
+  const message = typeof params.message === "string" ? params.message : undefined;
+  const store = useChatStore.getState();
+
+  if (store.isGenerating) {
+    throw new Error("Generation already in progress");
+  }
+
+  // Delegate to the store's sendMessage for normal type, which handles
+  // the full config internally. For other types we'd need the config
+  // which is only available in the React component layer.
+  // For now, only "normal" is supported from scripts.
+  if (type === "normal" && message) {
+    // We can't call sendMessage directly because it requires GenerationConfig.
+    // Instead, signal that we want generation by returning the intent —
+    // the host component will handle it.
+    return { intent: "generate", type, message };
+  }
+
+  return { intent: "generate", type, message };
+};
+
+/** getGenerationType() */
+export const getGenerationType: RpcHandler = () => {
+  return useChatStore.getState().generationType;
+};
+
+/** getStreamingContent() */
+export const getStreamingContent: RpcHandler = () => {
+  const store = useChatStore.getState();
+  return {
+    content: store.streamingContent,
+    reasoning: store.streamingReasoning,
+    isGenerating: store.isGenerating,
+  };
+};

--- a/client/lib/compat-sandbox/rpc-handlers/globals.ts
+++ b/client/lib/compat-sandbox/rpc-handlers/globals.ts
@@ -1,0 +1,77 @@
+/**
+ * RPC handlers: MVU global initialization pattern.
+ *
+ * MVU framework uses `initializeGlobal(name, value)` / `waitGlobalInitialized(name)`
+ * for cross-script coordination. We implement this as a simple in-memory registry
+ * with event-based notification.
+ */
+
+import type { RpcHandler } from "../rpc-registry";
+
+const globals = new Map<string, unknown>();
+const waiters = new Map<string, Array<(value: unknown) => void>>();
+
+/** initializeGlobal({ name, value }) */
+export const initializeGlobal: RpcHandler = (params) => {
+  const name = typeof params.name === "string" ? params.name : "";
+  if (!name) return false;
+
+  globals.set(name, params.value);
+
+  const pending = waiters.get(name);
+  if (pending) {
+    for (const resolve of pending) {
+      resolve(params.value);
+    }
+    waiters.delete(name);
+  }
+  return true;
+};
+
+/** waitGlobalInitialized({ name, timeout? }) */
+export const waitGlobalInitialized: RpcHandler = (params) => {
+  const name = typeof params.name === "string" ? params.name : "";
+  if (!name) return Promise.resolve(undefined);
+
+  if (globals.has(name)) {
+    return globals.get(name);
+  }
+
+  const timeout = typeof params.timeout === "number" ? params.timeout : 30000;
+  return new Promise<unknown>((resolve, reject) => {
+    const list = waiters.get(name) ?? [];
+    list.push(resolve);
+    waiters.set(name, list);
+
+    if (timeout > 0) {
+      setTimeout(() => {
+        const remaining = waiters.get(name);
+        if (remaining) {
+          const idx = remaining.indexOf(resolve);
+          if (idx >= 0) {
+            remaining.splice(idx, 1);
+            if (remaining.length === 0) waiters.delete(name);
+            reject(new Error(`waitGlobalInitialized("${name}") timed out after ${timeout}ms`));
+          }
+        }
+      }, timeout);
+    }
+  });
+};
+
+/** getGlobal({ name }) */
+export const getGlobal: RpcHandler = (params) => {
+  const name = typeof params.name === "string" ? params.name : "";
+  return globals.get(name);
+};
+
+/** clearGlobals() — resets all globals (for testing / character switch) */
+export function clearGlobals(): void {
+  globals.clear();
+  for (const [, pending] of waiters) {
+    for (const resolve of pending) {
+      resolve(undefined);
+    }
+  }
+  waiters.clear();
+}

--- a/client/lib/compat-sandbox/rpc-handlers/index.ts
+++ b/client/lib/compat-sandbox/rpc-handlers/index.ts
@@ -7,6 +7,32 @@ import type { RpcHandler } from "../rpc-registry";
 import { registerRpcAlias, registerRpcHandler } from "../rpc-registry";
 import { getContext, getVariables, requestWriteDone, getVariable, setVariable } from "./context";
 import { runSlashCommand } from "./commands";
+import {
+  getChatMessages,
+  getLastMessage,
+  getMessage,
+  getLastMessageId,
+  editMessage,
+  deleteMessageHandler,
+  addMessage,
+  getMessageCount,
+} from "./messages";
+import {
+  getCharacter,
+  getCharacterList,
+  getCurrentCharacterName,
+  getCharacterAvatarUrl,
+} from "./characters";
+import {
+  isGenerating,
+  stopGeneration,
+  generate,
+  getGenerationType,
+  getStreamingContent,
+} from "./generation";
+import { getConnectionSettings, getProvider, getModel } from "./connection";
+import { getWorldInfoBooks, getWorldInfoEntries, getActiveWorldInfoBookIds } from "./worldinfo";
+import { initializeGlobal, waitGlobalInitialized, getGlobal } from "./globals";
 
 let registered = false;
 
@@ -17,9 +43,44 @@ export const builtinRpcHandlerEntries: ReadonlyArray<readonly [string, RpcHandle
   ["getVariable", getVariable],
   ["setVariable", setVariable],
   ["runSlashCommand", runSlashCommand],
+  ["getChatMessages", getChatMessages],
+  ["getLastMessage", getLastMessage],
+  ["getMessage", getMessage],
+  ["getLastMessageId", getLastMessageId],
+  ["editMessage", editMessage],
+  ["deleteMessage", deleteMessageHandler],
+  ["addMessage", addMessage],
+  ["getMessageCount", getMessageCount],
+  ["getCharacter", getCharacter],
+  ["getCharacterList", getCharacterList],
+  ["getCurrentCharacterName", getCurrentCharacterName],
+  ["getCharacterAvatarUrl", getCharacterAvatarUrl],
+  ["isGenerating", isGenerating],
+  ["stopGeneration", stopGeneration],
+  ["generate", generate],
+  ["getGenerationType", getGenerationType],
+  ["getStreamingContent", getStreamingContent],
+  ["getConnectionSettings", getConnectionSettings],
+  ["getProvider", getProvider],
+  ["getModel", getModel],
+  ["getWorldInfoBooks", getWorldInfoBooks],
+  ["getWorldInfoEntries", getWorldInfoEntries],
+  ["getActiveWorldInfoBookIds", getActiveWorldInfoBookIds],
+  ["initializeGlobal", initializeGlobal],
+  ["waitGlobalInitialized", waitGlobalInitialized],
+  ["getGlobal", getGlobal],
 ] as const;
 
-export const builtinRpcAliasEntries: ReadonlyArray<readonly [string, string]> = [] as const;
+export const builtinRpcAliasEntries: ReadonlyArray<readonly [string, string]> = [
+  ["triggerSlash", "runSlashCommand"],
+  ["getCharacterNames", "getCharacterList"],
+  ["getCharData", "getCharacter"],
+  ["deleteChatMessages", "deleteMessage"],
+  ["setChatMessage", "editMessage"],
+  ["createChatMessages", "addMessage"],
+  ["getModelList", "getModel"],
+  ["stopAllGeneration", "stopGeneration"],
+] as const;
 
 export function registerBuiltinHandlers(): void {
   if (registered) return;

--- a/client/lib/compat-sandbox/rpc-handlers/messages.ts
+++ b/client/lib/compat-sandbox/rpc-handlers/messages.ts
@@ -1,0 +1,135 @@
+/**
+ * RPC handlers: chat message operations.
+ * Covers getChatMessages, getLastMessage, getMessage, editMessage,
+ * deleteMessage, addMessage — the core message APIs that JSR scripts need.
+ */
+
+import { useChatStore } from "@/stores/chat-store";
+import { chatApi } from "@/lib/api/chat";
+import type { RpcHandler } from "../rpc-registry";
+
+/** getChatMessages({ range?, role?, limit? }) */
+export const getChatMessages: RpcHandler = (params) => {
+  const messages = useChatStore.getState().messages;
+  let result = messages;
+
+  const role = typeof params.role === "string" ? params.role : undefined;
+  if (role) {
+    result = result.filter((m) => m.role === role);
+  }
+
+  const limit = typeof params.limit === "number" ? params.limit : undefined;
+  if (limit && limit > 0) {
+    result = result.slice(-limit);
+  }
+
+  return result.map((m) => ({
+    id: m.id,
+    role: m.role,
+    name: m.name,
+    content: m.content,
+    isHidden: m.isHidden,
+    swipeId: m.swipeId,
+    swipes: m.swipes,
+    extra: m.extra,
+    createdAt: m.createdAt,
+  }));
+};
+
+/** getLastMessage({ role? }) */
+export const getLastMessage: RpcHandler = (params) => {
+  const messages = useChatStore.getState().messages;
+  const role = typeof params.role === "string" ? params.role : undefined;
+  const filtered = role ? messages.filter((m) => m.role === role) : messages;
+  const last = filtered.at(-1);
+  if (!last) return null;
+
+  return {
+    id: last.id,
+    role: last.role,
+    name: last.name,
+    content: last.content,
+    swipeId: last.swipeId,
+    swipes: last.swipes,
+    extra: last.extra,
+  };
+};
+
+/** getMessage({ id }) */
+export const getMessage: RpcHandler = (params) => {
+  const id = typeof params.id === "number" ? params.id : null;
+  if (id == null) return null;
+
+  const message = useChatStore.getState().messages.find((m) => m.id === id);
+  if (!message) return null;
+
+  return {
+    id: message.id,
+    role: message.role,
+    name: message.name,
+    content: message.content,
+    isHidden: message.isHidden,
+    swipeId: message.swipeId,
+    swipes: message.swipes,
+    extra: message.extra,
+    createdAt: message.createdAt,
+  };
+};
+
+/** getLastMessageId() */
+export const getLastMessageId: RpcHandler = () => {
+  const messages = useChatStore.getState().messages;
+  return messages.at(-1)?.id ?? null;
+};
+
+/** editMessage({ id, content?, extra?, isHidden? }) */
+export const editMessage: RpcHandler = async (params) => {
+  const id = typeof params.id === "number" ? params.id : null;
+  if (id == null) return false;
+
+  const updates: Record<string, unknown> = {};
+  if (typeof params.content === "string") updates.content = params.content;
+  if (params.extra && typeof params.extra === "object") updates.extra = params.extra;
+  if (typeof params.isHidden === "boolean") updates.isHidden = params.isHidden;
+
+  if (Object.keys(updates).length === 0) return false;
+
+  const updated = await chatApi.updateMessage(id, updates);
+  useChatStore.setState((state) => ({
+    messages: state.messages.map((m) => (m.id === id ? updated : m)),
+  }));
+  return true;
+};
+
+/** deleteMessage({ id }) */
+export const deleteMessageHandler: RpcHandler = async (params) => {
+  const id = typeof params.id === "number" ? params.id : null;
+  if (id == null) return false;
+
+  await chatApi.deleteMessage(id);
+  useChatStore.setState((state) => ({
+    messages: state.messages.filter((m) => m.id !== id),
+  }));
+  return true;
+};
+
+/** addMessage({ role, content, name? }) */
+export const addMessage: RpcHandler = async (params, ctx) => {
+  const chatId = ctx.chatId;
+  if (chatId == null) return null;
+
+  const role = typeof params.role === "string" ? params.role : "system";
+  const content = typeof params.content === "string" ? params.content : "";
+  const name = typeof params.name === "string" ? params.name : undefined;
+
+  const message = await chatApi.addMessage(chatId, { role, content, name });
+  useChatStore.setState((state) => ({
+    messages: [...state.messages, message],
+  }));
+  return { id: message.id };
+};
+
+/** getMessageCount() */
+export const getMessageCount: RpcHandler = () => {
+  return useChatStore.getState().messages.length;
+};

--- a/client/lib/compat-sandbox/rpc-handlers/worldinfo.ts
+++ b/client/lib/compat-sandbox/rpc-handlers/worldinfo.ts
@@ -1,0 +1,44 @@
+/**
+ * RPC handlers: world-info / lorebook access (read-only).
+ */
+
+import { useWorldInfoStore } from "@/stores/world-info-store";
+import { worldInfoApi } from "@/lib/api/world-info";
+import type { RpcHandler } from "../rpc-registry";
+
+/** getWorldInfoBooks() */
+export const getWorldInfoBooks: RpcHandler = () => {
+  return useWorldInfoStore.getState().books.map((b) => ({
+    id: b.id,
+    name: b.name,
+    description: b.description,
+  }));
+};
+
+/** getWorldInfoEntries({ bookId }) */
+export const getWorldInfoEntries: RpcHandler = async (params) => {
+  const bookId = typeof params.bookId === "number" ? params.bookId : null;
+  if (bookId == null) return [];
+
+  const book = await worldInfoApi.getBook(bookId);
+  return book.entries.map((e) => ({
+    id: e.id,
+    uid: e.uid,
+    keys: e.keys,
+    secondaryKeys: e.secondaryKeys,
+    content: e.content,
+    comment: e.comment,
+    enabled: e.enabled,
+    position: e.position,
+    depth: e.depth,
+    constant: e.constant,
+    selective: e.selective,
+    probability: e.probability,
+    groupName: e.groupName,
+  }));
+};
+
+/** getActiveWorldInfoBookIds() */
+export const getActiveWorldInfoBookIds: RpcHandler = () => {
+  return useWorldInfoStore.getState().activeBookIds;
+};

--- a/client/src/__tests__/use-settings-panel-controller.test.ts
+++ b/client/src/__tests__/use-settings-panel-controller.test.ts
@@ -1,0 +1,90 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSettingsPanelController } from "@/hooks/use-settings-panel-controller";
+import { useConnectionStore } from "@/stores/connection-store";
+
+const { completeMock, listKeysMock, toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
+  completeMock: vi.fn(),
+  listKeysMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api/ai", () => ({
+  aiApi: {
+    complete: completeMock,
+  },
+}));
+
+vi.mock("@/lib/api/secret", () => ({
+  secretApi: {
+    listKeys: listKeysMock,
+    set: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
+}));
+
+describe("useSettingsPanelController", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    completeMock.mockReset();
+    listKeysMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+    listKeysMock.mockResolvedValue(["api_key_custom"]);
+    completeMock.mockResolvedValue({
+      content: "OK",
+      model: "gemini-3-flash-preview",
+      finishReason: "stop",
+    });
+
+    useConnectionStore.setState({
+      provider: "custom",
+      model: "gemini-3-flash-preview",
+      reverseProxy: "https://example.com/v1beta",
+      customModels: ["gemini-3-flash-preview"],
+      customApiFormat: "google",
+      topK: 40,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      connectionStatus: "idle",
+      connectionMessage: null,
+      apiKeyConfigured: {
+        openai: false,
+        anthropic: false,
+        google: false,
+        openrouter: false,
+        mistral: false,
+        custom: true,
+      },
+    });
+  });
+
+  it("passes customApiFormat and omits topK for custom google test requests", async () => {
+    const { result } = renderHook(() => useSettingsPanelController((key) => key));
+
+    await waitFor(() => {
+      expect(listKeysMock).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      await result.current.handleTestConnection();
+    });
+
+    expect(completeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "custom",
+        model: "gemini-3-flash-preview",
+        reverseProxy: "https://example.com/v1beta",
+        customApiFormat: "google",
+        topK: undefined,
+      }),
+    );
+  });
+});

--- a/client/src/compat-sandbox-app.tsx
+++ b/client/src/compat-sandbox-app.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import type { Message } from "@/lib/api/chat";
-import { MessageBubble } from "@/components/chat/message-bubble";
+import { CompatSandboxMessageView } from "@/components/chat/compat-sandbox-message-view";
+import { DotsLoader } from "@/components/ui/loader";
 import { useBridgeClient } from "@/lib/compat-sandbox/bridge-client";
 import { useCharacterStore } from "@/stores/character-store";
 import { useChatStore } from "@/stores/chat-store";
@@ -13,9 +14,20 @@ export function CompatSandboxApp() {
   useEffect(() => {
     if (!state.session) return;
 
+    const char = state.session.character;
+    if (import.meta.env.DEV) {
+      console.log("[compat-sandbox] session:init character", char.name, {
+        hasExtensions: !!char.extensions,
+        regexScriptCount: Array.isArray(char.extensions?.regex_scripts)
+          ? char.extensions.regex_scripts.length
+          : 0,
+        extensionKeys: char.extensions ? Object.keys(char.extensions) : [],
+      });
+    }
+
     useCharacterStore.setState({
-      selectedId: state.session.character.id,
-      characters: [state.session.character],
+      selectedId: char.id,
+      characters: [char],
     });
     useChatStore.setState({
       currentChatId: state.session.chatId,
@@ -45,10 +57,14 @@ export function CompatSandboxApp() {
   }, [state.session]);
 
   if (!state.session) {
-    return <div className="p-4 text-sm text-muted-foreground">Loading compat runtime…</div>;
+    return null;
   }
 
   const session = state.session;
+
+  const isSwipeGenerating =
+    session.isGenerating &&
+    (session.generationType === "swipe" || session.generationType === "regenerate");
 
   const runSlashCommand = async (command: string) => {
     await call("runSlashCommand", { command });
@@ -62,7 +78,7 @@ export function CompatSandboxApp() {
             state.streamingMessageId === message.id && message.id === latestAssistantMessageId;
 
           return (
-            <MessageBubble
+            <CompatSandboxMessageView
               key={message.id}
               messageId={message.id}
               role={message.role}
@@ -91,9 +107,10 @@ export function CompatSandboxApp() {
           );
         })}
 
-        {state.streamingMessageId === -1 &&
+        {session.isGenerating &&
+          !isSwipeGenerating &&
           (state.streamingContent || state.streamingReasoning || state.streamingStructured) && (
-            <MessageBubble
+            <CompatSandboxMessageView
               role="assistant"
               name={state.session.character.name}
               content={state.streamingContent}
@@ -105,6 +122,19 @@ export function CompatSandboxApp() {
               onStructuredCommandAction={() => undefined}
               onWidgetSlashCommand={runSlashCommand}
             />
+          )}
+
+        {session.isGenerating &&
+          !isSwipeGenerating &&
+          !state.streamingContent &&
+          !state.streamingReasoning &&
+          !state.streamingStructured && (
+            <div>
+              <p className="mb-1 text-xs font-medium text-muted-foreground">
+                {state.session.character.name ?? "Assistant"}
+              </p>
+              <DotsLoader size="md" className="text-muted-foreground" />
+            </div>
           )}
       </div>
     </main>

--- a/client/src/compat-sandbox-main.tsx
+++ b/client/src/compat-sandbox-main.tsx
@@ -1,5 +1,5 @@
+/** Sandbox entry: fewer font families than main app = less download + faster first paint. */
 import "@fontsource-variable/geist";
-import "@fontsource-variable/geist-mono";
 import "@fontsource-variable/noto-sans";
 import "./globals.css";
 import { StrictMode } from "react";
@@ -12,8 +12,24 @@ if (!rootElement) {
   throw new Error("Failed to find compat sandbox root");
 }
 
+function notifyReady() {
+  if (import.meta.env.DEV) {
+    console.log("[compat-sandbox] sending compat:ready");
+  }
+  window.parent.postMessage({ type: "compat:ready" }, "*");
+}
+
+/** Host pings after iframe onLoad / remount — must respond even before React hydrates (StrictMode). */
+window.addEventListener("message", (event: MessageEvent) => {
+  if (event.data?.type === "compat:request-ready") {
+    notifyReady();
+  }
+});
+
 createRoot(rootElement).render(
   <StrictMode>
     <CompatSandboxApp />
   </StrictMode>,
 );
+
+notifyReady();

--- a/server/src/modules/ai-provider/__tests__/ai-provider.service.spec.ts
+++ b/server/src/modules/ai-provider/__tests__/ai-provider.service.spec.ts
@@ -274,6 +274,34 @@ describe('AiProviderService', () => {
     ]);
   });
 
+  it('extracts content from text chunks with text, textDelta, and delta fields', async () => {
+    const service = createServiceWithKey('sk-test');
+    streamTextMock.mockReturnValue(
+      makeStream([
+        { type: 'text-delta', text: 'alpha' },
+        { type: 'text-delta', textDelta: 'beta' },
+        { type: 'text-delta', delta: 'gamma' },
+        { type: 'text', text: 'delta' },
+      ]),
+    );
+
+    const chunks = [];
+    for await (const chunk of service.streamComplete({
+      provider: 'openai',
+      model: 'gpt-5.2',
+      messages: [{ role: 'user', content: 'hello' }],
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([
+      { content: 'alpha' },
+      { content: 'beta' },
+      { content: 'gamma' },
+      { content: 'delta' },
+    ]);
+  });
+
   it('preserves explicit zero-valued sampling settings', async () => {
     const service = createServiceWithKey('sk-test');
 
@@ -295,6 +323,60 @@ describe('AiProviderService', () => {
     );
   });
 
+  it('omits topK for Google native SDK (custom + google format)', async () => {
+    const service = createServiceWithKey('sk-test');
+
+    await service.complete({
+      provider: 'custom',
+      customApiFormat: 'google',
+      reverseProxy: 'https://generativelanguage.googleapis.com',
+      model: 'gemini-3-flash-preview',
+      messages: [{ role: 'user', content: 'hello' }],
+      topK: 40,
+      topP: 0.9,
+    });
+
+    const args = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(args).not.toHaveProperty('topK');
+    expect(args.topP).toBe(0.9);
+  });
+
+  it('omits topK for google provider', async () => {
+    const service = createServiceWithKey('sk-test');
+
+    await service.complete({
+      provider: 'google',
+      model: 'gemini-3-flash-preview',
+      messages: [{ role: 'user', content: 'hello' }],
+      topK: 40,
+    });
+
+    const args = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(args).not.toHaveProperty('topK');
+  });
+
+  it('streamComplete omits topK from call and providerOptions when generationConfig carries topK', async () => {
+    const service = createServiceWithKey('sk-test');
+    streamTextMock.mockReturnValue({ fullStream: (async function* () {})() });
+
+    const chunks: unknown[] = [];
+    for await (const chunk of service.streamComplete({
+      provider: 'google',
+      model: 'gemini-3-flash-preview',
+      messages: [{ role: 'user', content: 'hello' }],
+      topK: 40,
+      generationConfig: { topK: 99 },
+    })) {
+      chunks.push(chunk);
+    }
+
+    const args = streamTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(args).not.toHaveProperty('topK');
+    const po = args.providerOptions as { google?: Record<string, unknown> } | undefined;
+    expect(po?.google).toBeDefined();
+    expect(po?.google).not.toHaveProperty('topK');
+  });
+
   it('extracts think-tag reasoning in structured streams when no native reasoning exists', async () => {
     const service = createServiceWithKey('sk-test');
     streamTextMock.mockReturnValue(
@@ -314,6 +396,27 @@ describe('AiProviderService', () => {
     }
 
     expect(chunks).toEqual([{ reasoning: 'fallback' }, { partial: { blocks: [] } }]);
+  });
+
+  it('parses structured streams from text-delta text chunks', async () => {
+    const service = createServiceWithKey('sk-test');
+    streamTextMock.mockReturnValue(
+      makeStream([{ type: 'text-delta', text: '{"blocks":[]}' }]),
+    );
+
+    const chunks = [];
+    for await (const chunk of service.streamStructured(
+      {
+        provider: 'openai',
+        model: 'gpt-5.2',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+      z.any(),
+    )) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([{ partial: { blocks: [] } }]);
   });
 
   it('does not duplicate think-tag reasoning when native reasoning chunks are present', async () => {

--- a/server/src/modules/ai-provider/ai-provider.service.ts
+++ b/server/src/modules/ai-provider/ai-provider.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable, BadRequestException, Logger } from '@nestjs/common';
 import { SecretService } from '../secret/secret.service';
 import { LocalEmbeddingService } from './local-embedding.service';
 import {
@@ -60,11 +60,24 @@ const MODEL_CATALOG: Record<string, Array<{ id: string; contextWindow: number }>
 type ProviderOptions = Record<string, NonNullable<CompletionRequest['generationConfig']>>;
 type EffectiveProvider = 'openai' | 'anthropic' | 'google' | 'mistral' | 'custom';
 const THINKING_TAG_RE = /<(think|thinking)(?:\s[^>]*)?>(?<inner>[\s\S]*?)<\/\1>/gi;
+type StreamTextPart = {
+  type?: string;
+  text?: string;
+  textDelta?: string;
+  delta?: string;
+  finishReason?: string;
+  rawFinishReason?: string;
+  error?: unknown;
+};
 
 @Injectable()
 export class AiProviderService {
+  private readonly logger = new Logger(AiProviderService.name);
   private modelCache = new Map<string, { models: ModelInfo[]; timestamp: number }>();
   private readonly CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+  private readonly streamDebugEnabled = ['1', 'true', 'yes', 'on'].includes(
+    (process.env.CHAT_DEBUG ?? '').toLowerCase(),
+  );
 
   constructor(
     private readonly secretService: SecretService,
@@ -155,6 +168,9 @@ export class AiProviderService {
     const nextConfig = this.toConfigObject(req.generationConfig) as NonNullable<
       CompletionRequest['generationConfig']
     >;
+    if (effectiveProvider === 'google' && 'topK' in nextConfig) {
+      delete nextConfig.topK;
+    }
     let changed = Object.keys(nextConfig).length > 0;
 
     if (req.reasoningEffort && nextConfig.reasoningEffort === undefined) {
@@ -250,7 +266,77 @@ export class AiProviderService {
     textDelta?: string;
     text?: string;
   }): string | undefined {
-    return part.delta ?? part.textDelta ?? part.text;
+    return part.text ?? part.textDelta ?? part.delta;
+  }
+
+  private getStreamPartText(part: StreamTextPart): string | undefined {
+    return part.text ?? part.textDelta ?? part.delta;
+  }
+
+  private logStreamEvent(kind: 'streamComplete' | 'streamStructured', part: StreamTextPart): void {
+    if (!this.streamDebugEnabled) return;
+
+    const type = part.type ?? 'unknown';
+    if (
+      ![
+        'start-step',
+        'finish-step',
+        'finish',
+        'error',
+        'raw',
+        'source',
+        'tool-call',
+        'tool-result',
+      ].includes(type)
+    ) {
+      return;
+    }
+
+    this.logger.debug(
+      `[${kind}] stream event ${JSON.stringify({
+        type,
+        hasText: Boolean(this.getStreamPartText(part)),
+        finishReason: part.finishReason ?? part.rawFinishReason,
+        hasError: part.error !== undefined,
+      })}`,
+    );
+  }
+
+  /**
+   * Boundary adaptation for @ai-sdk/google: the UI and request body may still carry `topK`
+   * (presets, user tuning, switching providers) — we only strip it at the SDK boundary so
+   * Gemini never receives unsupported options; this is not "disabling" user preference in
+   * storage, only omitting fields the Google API does not accept.
+   */
+  private usesGoogleGenerativeLanguageModel(req: CompletionRequest): boolean {
+    return this.resolveEffectiveProvider(req.provider, req.customApiFormat) === 'google';
+  }
+
+  /** Sampling fields passed to generateText / streamText (provider-specific omissions). */
+  private buildLanguageModelSampling(req: CompletionRequest): {
+    temperature?: number;
+    maxOutputTokens?: number;
+    topP?: number;
+    topK?: number;
+    frequencyPenalty?: number;
+    presencePenalty?: number;
+    stopSequences?: string[];
+  } {
+    const base = {
+      temperature: req.temperature,
+      maxOutputTokens: req.maxTokens,
+      topP: req.topP,
+      frequencyPenalty: req.frequencyPenalty ?? undefined,
+      presencePenalty: req.presencePenalty ?? undefined,
+      stopSequences: req.stop,
+    };
+    if (this.usesGoogleGenerativeLanguageModel(req)) {
+      return base;
+    }
+    return {
+      ...base,
+      topK: req.topK ?? undefined,
+    };
   }
 
   private createLanguageModel(
@@ -362,8 +448,17 @@ export class AiProviderService {
       return undefined;
     }
 
+    const payload = { ...(nextConfig as Record<string, unknown>) };
+    if (this.usesGoogleGenerativeLanguageModel(req)) {
+      delete payload.topK;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      return undefined;
+    }
+
     return {
-      [providerKey]: nextConfig,
+      [providerKey]: payload as NonNullable<CompletionRequest['generationConfig']>,
     };
   }
 
@@ -380,13 +475,7 @@ export class AiProviderService {
     const result = await generateText({
       model,
       messages: this.convertMessages(req.messages, req.assistantPrefill),
-      temperature: req.temperature,
-      maxOutputTokens: req.maxTokens,
-      topP: req.topP,
-      topK: req.topK ?? undefined,
-      frequencyPenalty: req.frequencyPenalty ?? undefined,
-      presencePenalty: req.presencePenalty ?? undefined,
-      stopSequences: req.stop,
+      ...this.buildLanguageModelSampling(req),
       providerOptions: this.getProviderOptions(req),
     });
 
@@ -423,46 +512,56 @@ export class AiProviderService {
     const result = streamText({
       model,
       messages: this.convertMessages(req.messages, req.assistantPrefill),
-      temperature: req.temperature,
-      maxOutputTokens: req.maxTokens,
-      topP: req.topP,
-      topK: req.topK ?? undefined,
-      frequencyPenalty: req.frequencyPenalty ?? undefined,
-      presencePenalty: req.presencePenalty ?? undefined,
-      stopSequences: req.stop,
+      ...this.buildLanguageModelSampling(req),
       abortSignal: signal,
       providerOptions: this.getProviderOptions(req),
     });
 
+    const seenTypes = new Set<string>();
+    let emittedContent = false;
     for await (const part of result.fullStream) {
-      const chunk = part as {
-        type?: string;
-        textDelta?: string;
-        delta?: string;
-        text?: string;
-      };
+      const chunk = part as StreamTextPart;
+      const chunkType = chunk.type ?? 'unknown';
+      seenTypes.add(chunkType);
+      this.logStreamEvent('streamComplete', chunk);
 
-      if (chunk.type === 'text-delta' && chunk.textDelta) {
-        yield { content: chunk.textDelta };
+      if (chunkType === 'text-delta') {
+        const content = this.getStreamPartText(chunk);
+        if (content) {
+          emittedContent = true;
+          yield { content };
+        }
         continue;
       }
-      if (chunk.type === 'reasoning-delta') {
+      if (chunkType === 'reasoning-delta') {
         const reasoningText = this.getReasoningText(chunk);
         if (reasoningText) {
+          emittedContent = true;
           yield { reasoning: reasoningText };
         }
         continue;
       }
-      if (chunk.type === 'text' && chunk.text) {
-        yield { content: chunk.text };
+      if (chunkType === 'text') {
+        const content = this.getStreamPartText(chunk);
+        if (content) {
+          emittedContent = true;
+          yield { content };
+        }
         continue;
       }
-      if (chunk.type === 'reasoning') {
+      if (chunkType === 'reasoning') {
         const reasoningText = this.getReasoningText(chunk);
         if (reasoningText) {
+          emittedContent = true;
           yield { reasoning: reasoningText };
         }
       }
+    }
+
+    if (!emittedContent && seenTypes.size > 0) {
+      this.logger.warn(
+        `[streamComplete] stream emitted no text or reasoning; seen chunk types=${[...seenTypes].join(',')}`,
+      );
     }
   }
 
@@ -489,53 +588,50 @@ export class AiProviderService {
     const result = streamText({
       model,
       messages: this.convertMessages(req.messages, req.assistantPrefill),
-      temperature: req.temperature,
-      maxOutputTokens: req.maxTokens,
-      topP: req.topP,
-      topK: req.topK ?? undefined,
-      frequencyPenalty: req.frequencyPenalty ?? undefined,
-      presencePenalty: req.presencePenalty ?? undefined,
-      stopSequences: req.stop,
+      ...this.buildLanguageModelSampling(req),
       abortSignal: signal,
       providerOptions: this.getProviderOptions(req),
     });
 
     let fullText = '';
     let hasNativeReasoning = false;
+    let emittedContent = false;
+    const seenTypes = new Set<string>();
     for await (const part of result.fullStream) {
-      const chunk = part as {
-        type?: string;
-        textDelta?: string;
-        delta?: string;
-        text?: string;
-      };
+      const chunk = part as StreamTextPart;
+      const chunkType = chunk.type ?? 'unknown';
+      seenTypes.add(chunkType);
+      this.logStreamEvent('streamStructured', chunk);
 
       // Reasoning chunks — pass through for the controller to handle
-      if (chunk.type === 'reasoning-delta') {
+      if (chunkType === 'reasoning-delta') {
         const reasoningText = this.getReasoningText(chunk);
         if (reasoningText) {
           hasNativeReasoning = true;
+          emittedContent = true;
           yield { reasoning: reasoningText };
         }
         continue;
       }
-      if (chunk.type === 'reasoning') {
+      if (chunkType === 'reasoning') {
         const reasoningText = this.getReasoningText(chunk);
         if (reasoningText) {
           hasNativeReasoning = true;
+          emittedContent = true;
           yield { reasoning: reasoningText };
         }
         continue;
       }
 
       // Text chunks — extract <think>/<thinking> blocks, then parse remaining as JSON
-      const deltaText = chunk.textDelta ?? chunk.text;
-      if ((chunk.type === 'text-delta' || chunk.type === 'text') && deltaText) {
+      const deltaText = this.getStreamPartText(chunk);
+      if ((chunkType === 'text-delta' || chunkType === 'text') && deltaText) {
         fullText += deltaText;
         const extracted = this.extractThinkingBlocks(fullText);
         if (extracted.reasoning.length > 0) {
           if (!hasNativeReasoning) {
             for (const thinkContent of extracted.reasoning) {
+              emittedContent = true;
               yield { reasoning: thinkContent };
             }
           }
@@ -544,9 +640,16 @@ export class AiProviderService {
 
         const parsed = tryParsePartialJson(fullText);
         if (parsed) {
+          emittedContent = true;
           yield { partial: parsed };
         }
       }
+    }
+
+    if (!emittedContent && seenTypes.size > 0) {
+      this.logger.warn(
+        `[streamStructured] stream emitted no partials or reasoning; seen chunk types=${[...seenTypes].join(',')}`,
+      );
     }
   }
 

--- a/server/src/modules/chat/chat-generation.controller.ts
+++ b/server/src/modules/chat/chat-generation.controller.ts
@@ -256,6 +256,9 @@ export class ChatGenerationController {
     let structuredResult: unknown = null;
     try {
       if (body.structuredOutput) {
+        this.logger.log(
+          `[generate] structured stream start chatId=${chatId} provider=${body.provider} model=${body.model} type=${generationType}`,
+        );
         // --- Structured output path: text stream + incremental JSON parsing ---
         promptMessages.push({
           role: 'system',
@@ -320,6 +323,9 @@ export class ChatGenerationController {
         }
       } else {
         // --- Text streaming path (existing behavior) ---
+        this.logger.log(
+          `[generate] stream start chatId=${chatId} provider=${body.provider} model=${body.model} type=${generationType}`,
+        );
         for await (const chunk of this.aiProviderService.streamComplete(
           completionRequest,
           abortController.signal,
@@ -353,6 +359,12 @@ export class ChatGenerationController {
           }
         }
       } // end else (text streaming path)
+
+      if (!abortController.signal.aborted && chunkCount === 0 && reasoningChunkCount === 0) {
+        this.logger.warn(
+          `[generate] stream produced no text or reasoning chunks (chatId=${chatId} provider=${body.provider} model=${body.model} structured=${Boolean(body.structuredOutput)}) — check API key, model id, and provider logs`,
+        );
+      }
 
       if (!abortController.signal.aborted) {
         await this.persistGenerationResult(


### PR DESCRIPTION
## 目的
扩展 compat iframe 的 API 面，让 JSR / MVU 兼容脚本可以调用更完整的宿主能力，同时把这层 surface 变成可回归验证的事实。

## 变更内容
- 新增 messages / characters / generation / connection / world-info / globals 等 RPC handlers
- 为 JSR TavernHelper 增加代表性 alias，兼容常见调用方式
- 新增 `CompatSandboxMessageView`，恢复并稳定 compat iframe 内的 streaming / reasoning 展示路径
- 将 iframe 消息视图接入共享 message view-model helper，和主聊天消息展示逻辑对齐
- 补充 registry 测试，锁定 canonical methods 与高价值 alias surface

## 接口与兼容性
- 扩大了 compat iframe 可调用的 RPC 方法面
- 不修改现有方法名语义
- 继续保持 bootstrap 与 `ArcTavern` Proxy 调用模式不变

## 验证
- `pnpm --filter @arctravern/client exec vp test run lib/compat-sandbox/__tests__/rpc-registry.test.ts lib/compat-sandbox/__tests__/generation.test.ts`
- `pnpm --filter @arctravern/client exec tsc --noEmit`
